### PR TITLE
new format: list of streams rather than map keyed by stream name

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -286,7 +286,9 @@ def initialize_stream(name, account, annotated_schema, state): # pylint: disable
 
 def get_streams_to_sync(account, annotated_schemas, state):
     streams = []
-    for name, schema in annotated_schemas['streams'].items():
+    for stream in annotated_schemas['streams']:
+        schema = stream.get('schema')
+        name = stream.get('stream')
         if schema.get('selected'):
             streams.append(initialize_stream(name, account, schema, state))
     return streams
@@ -332,11 +334,13 @@ def initialize_streams_for_discovery(): # pylint: disable=invalid-name
             for name in STREAMS]
 
 def discover_schemas():
-    result = {'streams': {}}
+    result = {'streams': []}
     streams = initialize_streams_for_discovery()
     for stream in streams:
         LOGGER.info('Loading schema for %s', stream.name)
-        result['streams'][stream.name] = load_schema(stream)
+        result['streams'].append({'stream': stream.name,
+                                  'tap_stream_id': stream.name,
+                                  'schema': load_schema(stream)})
     return result
 
 def do_discover():

--- a/tests/test_tap_facebook.py
+++ b/tests/test_tap_facebook.py
@@ -81,12 +81,20 @@ class TestPrimaryKeyInclusion(unittest.TestCase):
 class TestGetStreamsToSync(unittest.TestCase):
 
 
-    def test_foo(self):
+    def test_getting_streams_to_sync(self):
         annotated_schemas = {
-            'streams': {
-                'adcreative': {'selected': True},
-                'ads': {'selected': False}
-            }
+            'streams': [
+                {
+                    'stream': 'adcreative',
+                    'tap_stream_id': 'adcreative',
+                    'schema': {'selected': True}
+                },
+                {
+                    'stream': 'ads',
+                    'tap_stream_id': 'ads',
+                    'schema': {'selected': False}
+                }
+            ]
         }
 
         streams_to_sync = tap_facebook.get_streams_to_sync(None, annotated_schemas, None)


### PR DESCRIPTION
use the new format for discovered and annotated schemas (introduced in [tap-mysql](https://github.com/singer-io/tap-mysql)).