### PR TITLE
set 'automatic' inclusion for undocumented fields

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -322,7 +322,7 @@ def load_schema(stream):
     field_class = stream.field_class
     schema = utils.load_json(path)
     for k in schema['properties']:
-        if k in set(stream.key_properties):
+        if k in set(stream.key_properties) or k not in field_class.__dict__:
             schema['properties'][k]['inclusion'] = 'automatic'
         elif k in field_class.__dict__:
             schema['properties'][k]['inclusion'] = 'available'


### PR DESCRIPTION
the hardcoded schemas define some fields which are not documented in the SDK. presently we're not giving such fields an `inclusion` property. this change will give them an inclusion of `'automatic'`. an example of such a field is `targeting` on the `ads` stream.

SDK does not include `targeting` field for `Ad`:
https://github.com/facebook/facebook-python-ads-sdk/blob/master/facebookads/adobjects/ad.py#L45-L73

But we have it in the schema:
https://github.com/singer-io/tap-facebook/blob/master/tap_facebook/schemas/ads.json#L103

