### PR TITLE
Advance the bookmark using time_ranges until

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -255,6 +255,12 @@ class AdsInsights(Stream):
                     min_date_start_for_job = rec['date_start']
                 yield {'record': rec}
             LOGGER.info('Got %d results for insights job', count)
+
+            # when min_date_start_for_job stays None, we should still update the bookmark using 'until' in time_ranges
+            if min_date_start_for_job == None:
+                for range in params['time_ranges']:
+                    if range['until']:
+                        min_date_start_for_job = range['until']
             yield {'state': self.state.advance(self.name, min_date_start_for_job)} # pylint: disable=no-member
 
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -256,11 +256,12 @@ class AdsInsights(Stream):
                 yield {'record': rec}
             LOGGER.info('Got %d results for insights job', count)
 
-            # when min_date_start_for_job stays None, we should still update the bookmark using 'until' in time_ranges
-            if min_date_start_for_job == None:
-                for range in params['time_ranges']:
-                    if range['until']:
-                        min_date_start_for_job = range['until']
+            # when min_date_start_for_job stays None, we should
+            # still update the bookmark using 'until' in time_ranges
+            if min_date_start_for_job is None:
+                for time_range in params['time_ranges']:
+                    if time_range['until']:
+                        min_date_start_for_job = time_range['until']
             yield {'state': self.state.advance(self.name, min_date_start_for_job)} # pylint: disable=no-member
 
 


### PR DESCRIPTION
AdInsights jobs can produce no data. We should still move the bookmark forward even when no data comes back or else we'll never reach a more recent date.