### PR TITLE
Fix inclusion for some fields

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -437,6 +437,9 @@ def load_schema(stream):
             schema['properties'][k]['inclusion'] = 'automatic'
         elif k in field_class.__dict__:
             schema['properties'][k]['inclusion'] = 'available'
+        else:
+            LOGGER.warn('Property %s.%s is not defined in the facebookads library',
+                        stream.name, k)
     return schema
 
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -435,11 +435,13 @@ def load_schema(stream):
     for k in schema['properties']:
         if k in set(stream.key_properties):
             schema['properties'][k]['inclusion'] = 'automatic'
-        elif k in field_class.__dict__:
-            schema['properties'][k]['inclusion'] = 'available'
         else:
-            LOGGER.warn('Property %s.%s is not defined in the facebookads library',
-                        stream.name, k)
+            if k not in field_class.__dict__:
+                LOGGER.warning(
+                    'Property %s.%s is not defined in the facebookads library',
+                    stream.name, k)
+            schema['properties'][k]['inclusion'] = 'available'
+
     return schema
 
 

--- a/tap_facebook/schemas/adcreative.json
+++ b/tap_facebook/schemas/adcreative.json
@@ -67,12 +67,6 @@
         "string"
       ]
     },
-    "branded_content_sponsor_page_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-    },
     "call_to_action_type": {
       "type": [
         "null",

--- a/tap_facebook/schemas/campaigns.json
+++ b/tap_facebook/schemas/campaigns.json
@@ -50,10 +50,6 @@
       "type": "string",
       "format": "date-time"
     },
-    "end_time": {
-      "type": "string",
-      "format": "date-time"
-    },
     "ads": {
       "properties": {
         "data": {


### PR DESCRIPTION
We noticed that when we run the tap in Stitch, the UI's "track all fields" ignores several fields. Those fields happen to be ones that don't have an "inclusion" property set in the output of discovery. We're not setting the "inclusion" property because those fields don't seem to exist in the facebookads library. There seem to be two cases:

1. The field really doesn't exist in the facebook api and we shouldn't be asking for it. This was the case for two of the fields.
2. The field isn't a property on the facebookads object because it's a nested object or a breakdown or something. We _should_ be asking for these fields.

So I removed the two bad fields and changed tap-facebook so it will mark all fields in the schema as available. I think this is appropriate because it doesn't make sense to list fields in the schema that aren't available in the API.

I ran tap-tester on it and it passed.