### PR TITLE
Feature/bookmarks for ads

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -249,7 +249,6 @@ def get_start(stream, bookmark_key):
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
     if current_bookmark is None:
         if isinstance(stream, IncrementalStream):
-            LOGGER.info("no bookmark found for %s, will perform full sync...", tap_stream_id)
             return None
         else:
             LOGGER.info("no bookmark found for %s, using start_date instead...%s", tap_stream_id, CONFIG['start_date'])

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -252,11 +252,12 @@ def get_start(state, tap_stream_id, bookmark_key):
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
     if current_bookmark is None:
         if tap_stream_id in INCREMENTAL_STREAMS:
+            LOGGER.info("no bookmark found for %s, will perform full sync...", tap_stream_id)
             return pendulum.min
         else:
-            LOGGER.info("using start_date instead...%s", CONFIG['start_date'])
+            LOGGER.info("no bookmark found for %s, using start_date instead...%s", tap_stream_id, CONFIG['start_date'])
             return pendulum.parse(CONFIG['start_date'])
-    LOGGER.info("found current bookmark %s", current_bookmark)
+    LOGGER.info("found current bookmark for %s:  %s", tap_stream_id, current_bookmark)
     return pendulum.parse(current_bookmark)
 
 def advance_bookmark(state, tap_stream_id, bookmark_key, date):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -118,6 +118,28 @@ class Stream(object):
                     fields.add(k)
         return fields
 
+@attr.s
+class IncrementalStream(Stream):
+
+    state = attr.ib()
+
+    def __attrs_post_init__(self):
+        self.current_bookmark = get_start(self.state or {}, self.name, UPDATED_TIME_KEY)
+
+    def _iterate(self, recordset, record_preparation):
+        max_bookmark = None
+        for record in recordset:
+            record = record_preparation(record)
+            updated_at = pendulum.parse(record[UPDATED_TIME_KEY])
+
+            if self.current_bookmark >= updated_at:
+                continue
+            if not max_bookmark or updated_at > max_bookmark:
+                max_bookmark = updated_at
+            yield {'record': record}
+
+        if max_bookmark:
+            yield {'state': advance_bookmark(self.state, self.name, UPDATED_TIME_KEY, str(max_bookmark))}
 
 class AdCreative(Stream):
     '''
@@ -137,12 +159,10 @@ class AdCreative(Stream):
             yield {'record': a.export_all_data()}
 
 
-@attr.s
-class Ads(Stream):
+class Ads(IncrementalStream):
     '''
     doc: https://developers.facebook.com/docs/marketing-api/reference/adgroup
     '''
-    state = attr.ib()
 
     field_class = fb_ad.Ad.Field
     key_properties = ['id']
@@ -152,29 +172,18 @@ class Ads(Stream):
         def do_request():
             return self.account.get_ads(fields=self.fields(), params={'limit': RESULT_RETURN_LIMIT}) # pylint: disable=no-member
 
-        current_bookmark = get_start(self.state, self.name, UPDATED_TIME_KEY)
+        def prepare_record(ad):
+            return ad.export_all_data()
+
         ads = do_request()
-        max_bookmark = None
-        for ad in ads: # pylint: disable=invalid-name
-            record = ad.export_all_data()
-            updated_at = pendulum.parse(ad[UPDATED_TIME_KEY])
-
-            if current_bookmark >= updated_at:
-                continue
-            if not max_bookmark or updated_at > max_bookmark:
-                max_bookmark = updated_at
-            yield {'record': record}
-
-        if max_bookmark:
-            yield {'state': advance_bookmark(self.state, self.name, UPDATED_TIME_KEY, str(max_bookmark))}
+        for message in self._iterate(ads, prepare_record):
+            yield message
 
 
-@attr.s
-class AdSets(Stream):
+class AdSets(IncrementalStream):
     '''
     doc: https://developers.facebook.com/docs/marketing-api/reference/ad-campaign
     '''
-    state = attr.ib()
 
     field_class = adset.AdSet.Field
     key_properties = ['id']
@@ -185,26 +194,15 @@ class AdSets(Stream):
             return self.account.get_ad_sets(fields=self.fields(), # pylint: disable=no-member
                                             params={'limit': RESULT_RETURN_LIMIT})
 
-        current_bookmark = get_start(self.state, self.name, UPDATED_TIME_KEY)
+        def prepare_record(ad_set):
+            return ad_set.export_all_data()
+
         ad_sets = do_request()
-        max_bookmark = None
-        for ad_set in ad_sets:
-            record = ad_set.export_all_data()
-            updated_at = pendulum.parse(ad_set[UPDATED_TIME_KEY])
-
-            if current_bookmark >= updated_at:
-                continue
-            if not max_bookmark or updated_at > max_bookmark:
-                max_bookmark = updated_at
-            yield {'record': record}
-
-        if max_bookmark:
-            yield {'state': advance_bookmark(self.state, self.name, UPDATED_TIME_KEY, str(max_bookmark))}
+        for message in self._iterate(ad_sets, prepare_record):
+            yield message
 
 
-@attr.s
-class Campaigns(Stream):
-    state = attr.ib()
+class Campaigns(IncrementalStream):
 
     field_class = fb_campaign.Campaign.Field
     key_properties = ['id']
@@ -218,10 +216,7 @@ class Campaigns(Stream):
         def do_request():
             return self.account.get_campaigns(fields=fields, params={'limit': RESULT_RETURN_LIMIT}) # pylint: disable=no-member
 
-        current_bookmark = get_start(self.state, self.name, UPDATED_TIME_KEY)
-        campaigns = do_request()
-        max_bookmark = None
-        for campaign in campaigns:
+        def prepare_record(campaign):
             campaign_out = {}
             for k in campaign:
                 campaign_out[k] = campaign[k]
@@ -231,17 +226,12 @@ class Campaigns(Stream):
                 ids = [ad['id'] for ad in campaign.get_ads()]
                 for ad_id in ids:
                     campaign_out['ads']['data'].append({'id': ad_id})
+            return campaign_out
 
-            updated_at = pendulum.parse(campaign[UPDATED_TIME_KEY])
+        campaigns = do_request()
+        for message in self._iterate(campaigns, prepare_record):
+            yield message
 
-            if current_bookmark >= updated_at:
-                continue
-            if not max_bookmark or updated_at > max_bookmark:
-                max_bookmark = updated_at
-            yield {'record': campaign_out}
-
-        if max_bookmark:
-            yield {'state': advance_bookmark(self.state, self.name, UPDATED_TIME_KEY, str(max_bookmark))}
 
 ALL_ACTION_ATTRIBUTION_WINDOWS = [
     '1d_click',

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -165,7 +165,7 @@ class Ads(IncrementalStream):
     '''
 
     field_class = fb_ad.Ad.Field
-    key_properties = ['id']
+    key_properties = ['id', 'updated_time']
 
     def __iter__(self):
         @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
@@ -186,7 +186,7 @@ class AdSets(IncrementalStream):
     '''
 
     field_class = adset.AdSet.Field
-    key_properties = ['id']
+    key_properties = ['id', 'updated_time']
 
     def __iter__(self):
         @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
@@ -475,7 +475,7 @@ def load_schema(stream):
     field_class = stream.field_class
     schema = utils.load_json(path)
     for k in schema['properties']:
-        if k in set(stream.key_properties) or k == UPDATED_TIME_KEY:
+        if k in set(stream.key_properties):
             schema['properties'][k]['inclusion'] = 'automatic'
         else:
             if k not in field_class.__dict__:

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -245,7 +245,7 @@ ALL_ACTION_BREAKDOWNS = [
 
 def get_start(stream, bookmark_key):
     tap_stream_id = stream.name
-    state = stream.state
+    state = stream.state or {}
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
     if current_bookmark is None:
         if isinstance(stream, IncrementalStream):
@@ -258,7 +258,7 @@ def get_start(stream, bookmark_key):
 
 def advance_bookmark(stream, bookmark_key, date):
     tap_stream_id = stream.name
-    state = stream.state
+    state = stream.state or {}
     LOGGER.info('advance(%s, %s)', tap_stream_id, date)
     date = pendulum.parse(date) if date else None
     current_bookmark = get_start(stream, bookmark_key)

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -50,6 +50,11 @@ STREAMS = [
     'ads_insights_country',
     'ads_insights_platform_and_device']
 
+FULL_TABLE_STREAMS = [
+    'adcreative',
+    'ads',
+    'adsets',
+    'campaigns']
 
 REQUIRED_CONFIG_KEYS = ['start_date', 'account_id', 'access_token']
 LOGGER = singer.get_logger()
@@ -132,10 +137,13 @@ class AdCreative(Stream):
             yield {'record': a.export_all_data()}
 
 
+@attr.s
 class Ads(Stream):
     '''
     doc: https://developers.facebook.com/docs/marketing-api/reference/adgroup
     '''
+    state = attr.ib()
+
     field_class = fb_ad.Ad.Field
     key_properties = ['id', 'updated_time']
 
@@ -143,15 +151,31 @@ class Ads(Stream):
         @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
         def do_request():
             return self.account.get_ads(fields=self.fields(), params={'limit': RESULT_RETURN_LIMIT}) # pylint: disable=no-member
+
+        current_bookmark = pendulum.parse(get_start(self.state, self.name, "updated_time"))
         ads = do_request()
+        max_bookmark = None
         for ad in ads: # pylint: disable=invalid-name
-            yield {'record': ad.export_all_data()}
+            record = ad.export_all_data()
+            updated_at = pendulum.parse(ad['updated_time'])
+
+            if current_bookmark >= updated_at:
+                continue
+            if not max_bookmark or updated_at > max_bookmark:
+                max_bookmark = updated_at
+            yield {'record': record}
+
+        if max_bookmark:
+            yield {'state': advance_bookmark(self.state, self.name, "updated_time", str(max_bookmark))}
 
 
+@attr.s
 class AdSets(Stream):
     '''
     doc: https://developers.facebook.com/docs/marketing-api/reference/ad-campaign
     '''
+    state = attr.ib()
+
     field_class = adset.AdSet.Field
     key_properties = ['id', 'updated_time']
 
@@ -160,12 +184,28 @@ class AdSets(Stream):
         def do_request():
             return self.account.get_ad_sets(fields=self.fields(), # pylint: disable=no-member
                                             params={'limit': RESULT_RETURN_LIMIT})
+
+        current_bookmark = pendulum.parse(get_start(self.state, self.name, "updated_time"))
         ad_sets = do_request()
+        max_bookmark = None
         for ad_set in ad_sets:
-            yield {'record': ad_set.export_all_data()}
+            record = ad_set.export_all_data()
+            updated_at = pendulum.parse(ad_set['updated_time'])
+
+            if current_bookmark >= updated_at:
+                continue
+            if not max_bookmark or updated_at > max_bookmark:
+                max_bookmark = updated_at
+            yield {'record': record}
+
+        if max_bookmark:
+            yield {'state': advance_bookmark(self.state, self.name, "updated_time", str(max_bookmark))}
 
 
+@attr.s
 class Campaigns(Stream):
+    state = attr.ib()
+
     field_class = fb_campaign.Campaign.Field
     key_properties = ['id']
 
@@ -178,7 +218,9 @@ class Campaigns(Stream):
         def do_request():
             return self.account.get_campaigns(fields=fields, params={'limit': RESULT_RETURN_LIMIT}) # pylint: disable=no-member
 
+        current_bookmark = pendulum.parse(get_start(self.state, self.name, "updated_time"))
         campaigns = do_request()
+        max_bookmark = None
         for campaign in campaigns:
             campaign_out = {}
             for k in campaign:
@@ -190,8 +232,16 @@ class Campaigns(Stream):
                 for ad_id in ids:
                     campaign_out['ads']['data'].append({'id': ad_id})
 
+            updated_at = pendulum.parse(campaign['updated_time'])
+
+            if current_bookmark >= updated_at:
+                continue
+            if not max_bookmark or updated_at > max_bookmark:
+                max_bookmark = updated_at
             yield {'record': campaign_out}
 
+        if max_bookmark:
+            yield {'state': advance_bookmark(self.state, self.name, "updated_time", str(max_bookmark))}
 
 ALL_ACTION_ATTRIBUTION_WINDOWS = [
     '1d_click',
@@ -210,10 +260,13 @@ ALL_ACTION_BREAKDOWNS = [
 
 def get_start(state, tap_stream_id, bookmark_key):
     current_bookmark = singer.get_bookmark(state, tap_stream_id, bookmark_key)
-    LOGGER.info("found current bookmark %s", current_bookmark)
     if current_bookmark is None:
-        LOGGER.info("using start_date instead...%s", CONFIG['start_date'])
-        return CONFIG['start_date']
+        if tap_stream_id in FULL_TABLE_STREAMS:
+            return str(pendulum.min)
+        else:
+            LOGGER.info("using start_date instead...%s", CONFIG['start_date'])
+            return CONFIG['start_date']
+    LOGGER.info("found current bookmark %s", current_bookmark)
     return current_bookmark
 
 def advance_bookmark(state, tap_stream_id, bookmark_key, date):
@@ -229,7 +282,7 @@ def advance_bookmark(state, tap_stream_id, bookmark_key, date):
         LOGGER.info('Bookmark for stream %s is currently %s, ' +
                     'advancing to %s',
                     tap_stream_id, current_bookmark, date)
-        state = singer.write_bookmark(state, tap_stream_id, bookmark_key, date.to_date_string())
+        state = singer.write_bookmark(state, tap_stream_id, bookmark_key, str(date))
     else:
         LOGGER.info('Bookmark for stream %s is currently %s ' +
                     'not changing to to %s',
@@ -371,15 +424,14 @@ INSIGHTS_BREAKDOWNS_OPTIONS = {
 def initialize_stream(name, account, stream_alias, annotated_schema, state): # pylint: disable=too-many-return-statements
 
     if name in INSIGHTS_BREAKDOWNS_OPTIONS:
-        return AdsInsights(name, account, stream_alias, annotated_schema,
-                           state=state,
+        return AdsInsights(name, account, stream_alias, annotated_schema, state=state,
                            options=INSIGHTS_BREAKDOWNS_OPTIONS[name])
     elif name == 'campaigns':
-        return Campaigns(name, account, stream_alias, annotated_schema)
+        return Campaigns(name, account, stream_alias, annotated_schema, state=state)
     elif name == 'adsets':
-        return AdSets(name, account, stream_alias, annotated_schema)
+        return AdSets(name, account, stream_alias, annotated_schema, state=state)
     elif name == 'ads':
-        return Ads(name, account, stream_alias, annotated_schema)
+        return Ads(name, account, stream_alias, annotated_schema, state=state)
     elif name == 'adcreative':
         return AdCreative(name, account, stream_alias, annotated_schema)
     else:


### PR DESCRIPTION
Adding bookmarks for the streams below that have an `updated_time` field to rely on for bookmarking. The absence of a bookmark for these streams will be treated as `pendulum.min` (`0001-01-01T00:00:00+00:00`) for the purposes of fully syncing.

- Ads
- AdSets
- Campaigns

These streams will still pull back all of the data, but will only emit those newer than the latest bookmark.

**Note:** Unfortunately, AdCreative does not have anything that looks like a reliable ordered bookmark, so it will still emit all records each run of the tap.