### PR TITLE
Adding time extracted and bookmark properties

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ setup(name='tap-facebook',
       py_modules=['tap_facebook'],
       install_requires=[
           'attrs==16.3.0',
-          'backoff==1.4.0',
+          'backoff==1.3.2',
           'facebookads==2.10.1',
           'pendulum==1.2.0',
           'requests==2.12.4',
-          'singer-python==3.2.1',
+          'singer-python==5.0.2',
       ],
       entry_points='''
           [console_scripts]

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -52,15 +52,16 @@ STREAMS = [
 
 REQUIRED_CONFIG_KEYS = ['start_date', 'account_id', 'access_token']
 UPDATED_TIME_KEY = 'updated_time'
+START_DATE_KEY = 'date_start'
 
 BOOKMARK_KEYS = {
     'ads': UPDATED_TIME_KEY,
     'adsets': UPDATED_TIME_KEY,
     'campaigns': UPDATED_TIME_KEY,
-    'ads_insights': 'date_start',
-    'ads_insights_age_and_gender': 'date_start',
-    'ads_insights_country': 'date_start',
-    'ads_insights_platform_and_device:': 'date_start'
+    'ads_insights': START_DATE_KEY,
+    'ads_insights_age_and_gender': START_DATE_KEY,
+    'ads_insights_country': START_DATE_KEY,
+    'ads_insights_platform_and_device:': START_DATE_KEY
 }
 
 LOGGER = singer.get_logger()
@@ -303,7 +304,7 @@ class AdsInsights(Stream):
     time_increment = attr.ib(default=1)
     limit = attr.ib(default=RESULT_RETURN_LIMIT)
 
-    bookmark_key = "date_start"
+    bookmark_key = START_DATE_KEY
 
     invalid_insights_fields = ['impression_device', 'publisher_platform', 'platform_position',
                                'age', 'gender', 'country', 'placement']


### PR DESCRIPTION
Tested on the 'ads' stream.  Attaching log showing time_extracted property set in a RECORD message, and bookmark_properties list populated in a SCHEMA message.
[test_tap_facebook_ads_stream.log](https://github.com/singer-io/tap-facebook/files/1548515/test_tap_facebook_ads_stream.log)
