### PR TITLE
don't replicate adcreative.use_page_actor_override

### DIFF
--- a/tap_facebook/schemas/adcreative.json
+++ b/tap_facebook/schemas/adcreative.json
@@ -1432,12 +1432,6 @@
         "string"
       ]
     },
-    "use_page_actor_override": {
-      "type": [
-        "null",
-        "boolean"
-      ]
-    },
     "video_id": {
       "type": [
         "null",


### PR DESCRIPTION
This change drops support for the `adcreative.use_page_actor_override` field. Querying this field often causes 400 errors, so we're just getting rid of it.

[Facebook bug](https://developers.facebook.com/bugs/262625957597388/)

Also, we're going to make this a minor version bump. Even though it's technically a breaking change, this field is obscure enough that its deprecation doesn't warrant a major version increment.

I verified that `use_page_actor_override` is not present in the `fields` list of the adcreative endpoint query (even if it's `selected`), and that it's not present in the discovered schema.