### PR TITLE
Attempting to fix 500's during filtering filtering

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -162,7 +162,6 @@ class IncrementalStream(Stream):
     def _iterate(self, recordset, record_preparation):
         max_bookmark = None
         for record in recordset:
-            record = record_preparation(record)
             updated_at = pendulum.parse(record[UPDATED_TIME_KEY])
 
             if self.current_bookmark and self.current_bookmark >= updated_at:
@@ -209,6 +208,8 @@ class Ads(IncrementalStream):
             include_deleted = CONFIG.get('include_deleted', 'false')
             if include_deleted.lower() == 'true':
                 params.update({'filtering': get_delivery_info_filter('ad')})
+            if self.current_bookmark:
+                params['filtering'].append({'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
             return self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(ad):
@@ -234,6 +235,8 @@ class AdSets(IncrementalStream):
             include_deleted = CONFIG.get('include_deleted', 'false')
             if include_deleted.lower() == 'true':
                 params.update({'filtering': get_delivery_info_filter('adset')})
+            if self.current_bookmark:
+                params['filtering'].append({'field': 'adset.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
             return self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(ad_set):
@@ -259,6 +262,8 @@ class Campaigns(IncrementalStream):
             include_deleted = CONFIG.get('include_deleted', 'false')
             if include_deleted.lower() == 'true':
                 params.update({'filtering': get_delivery_info_filter('campaign')})
+            if self.current_bookmark:
+                params['filtering'].append({'field': 'campaign.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
             return self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(campaign):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -83,8 +83,7 @@ def transform_datetime_string(dts):
     return singer.strftime(parsed_dt)
 
 def get_delivery_info_filter(stream_type):
-    retDict = [
-        {
+    return {
             "field": stream_type + ".delivery_info",
             "operator": "IN",
             "value": ["active", "archived", "completed", "limited",
@@ -92,9 +91,7 @@ def get_delivery_info_filter(stream_type):
                       "pending_review", "permanently_deleted",
                       "recently_completed", "recently_rejected",
                       "rejected", "scheduled", "inactive"]
-        }
-    ]
-    return retDict
+    }
 
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
@@ -206,10 +203,14 @@ class Ads(IncrementalStream):
         def do_request():
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
+            filtering_params = []
             if include_deleted.lower() == 'true':
-                params.update({'filtering': get_delivery_info_filter('ad')})
+                filtering_params.append(get_delivery_info_filter('ad'))
             if self.current_bookmark:
-                params['filtering'].append({'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+                filtering_params.append({'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+
+            if filtering_params:
+                params.update({'filtering': filtering_params})
             return self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(ad):
@@ -233,10 +234,14 @@ class AdSets(IncrementalStream):
         def do_request():
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
+            filtering_params = []
             if include_deleted.lower() == 'true':
-                params.update({'filtering': get_delivery_info_filter('adset')})
+                filtering_params.append(get_delivery_info_filter('adset'))
             if self.current_bookmark:
-                params['filtering'].append({'field': 'adset.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+                filtering_params.append({'field': 'adset.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+
+            if filtering_params:
+                params.update({'filtering': filtering_params})
             return self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(ad_set):
@@ -261,10 +266,14 @@ class Campaigns(IncrementalStream):
         def do_request():
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
+            filtering_params = []
             if include_deleted.lower() == 'true':
-                params.update({'filtering': get_delivery_info_filter('campaign')})
+                filtering_params.append(get_delivery_info_filter('campaign'))
             if self.current_bookmark:
-                params['filtering'].append({'field': 'campaign.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+                filtering_params.append({'field': 'campaign.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
+
+            if filtering_params:
+                params.update({'filtering': filtering_params})
             return self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(campaign):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -254,6 +254,7 @@ class Campaigns(IncrementalStream):
 
     def __iter__(self):
         props = self.fields()
+        fields = [k for k in props if k != 'ads']
         pull_ads = 'ads' in props
 
         @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
@@ -267,10 +268,7 @@ class Campaigns(IncrementalStream):
             return self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
         def prepare_record(campaign):
-            campaign_out = campaign.remote_read(fields=self.fields()).export_all_data()
-            #for k in campaign:
-            #    campaign_out[k] = campaign[k]
-
+            campaign_out = campaign.remote_read(fields=fields).export_all_data()
             if pull_ads:
                 campaign_out['ads'] = {'data': []}
                 ids = [ad['id'] for ad in campaign.get_ads()]


### PR DESCRIPTION
We suspect there are one of 2 issues:

* The URL and query params were too long / complicated and would cause Facebook to issue a 500 error.
* The next-page request would be too long or complicated and would cause the same behavior.

This PR addresses both concerns:

* Retrieve ads/adsets/campaigns using only automatic fields and then retrieve the full object later
* Add a filtering parameter to limit the number of results returned when we have a bookmark