### PR TITLE
Split up filter query

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -82,17 +82,26 @@ def transform_datetime_string(dts):
         parsed_dt = parsed_dt.astimezone(timezone.utc)
     return singer.strftime(parsed_dt)
 
-def get_delivery_info_filter(stream_type):
-    return {
-            "field": stream_type + ".delivery_info",
-            "operator": "IN",
-            "value": ["active", "archived", "completed", "limited",
-                      "not_delivering", "deleted", "not_published",
-                      "pending_review", "permanently_deleted",
-                      "recently_completed", "recently_rejected",
-                      "rejected", "scheduled", "inactive"]
+def iter_delivery_info_filter(stream_type):
+    filt = {
+        "field": stream_type + ".delivery_info",
+        "operator": "IN",
     }
 
+    filt_values = [
+        "active", "archived", "completed",
+        "limited", "not_delivering", "deleted",
+        "not_published", "pending_review", "permanently_deleted",
+        "recently_completed", "recently_rejected", "rejected",
+        "scheduled", "inactive"]
+
+    sub_list_length = 3
+    start_index = 0
+    while start_index < len(filt_values):
+        end_index = min((start_index + sub_list_length),(len(filt_values)+1))
+        filt['value'] = filt_values[start_index:end_index]
+        yield filt
+        start_index += sub_list_length
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
     def log_retry_attempt(details):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -213,14 +213,23 @@ class Ads(IncrementalStream):
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
             filtering_params = []
-            if include_deleted.lower() == 'true':
-                filtering_params.append(get_delivery_info_filter('ad'))
+            ads = []
             if self.current_bookmark:
                 filtering_params.append({'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
-
-            if filtering_params:
+            if include_deleted.lower() == 'true':
+                for del_info_filt in iter_delivery_info_filter('ad'):
+                    if len(filtering_params) > 1:
+                        filtering_params.pop()
+                    filtering_params.append(del_info_filt)
+                    params.update({'filtering': filtering_params})
+                    filt_ads = self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                    ads.extend(filt_ads)
+            elif filtering_params:
                 params.update({'filtering': filtering_params})
-            return self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                ads = self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            else:
+                ads =  self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            return ads
 
         def prepare_record(ad):
             return ad.remote_read(fields=self.fields()).export_all_data()
@@ -244,14 +253,23 @@ class AdSets(IncrementalStream):
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
             filtering_params = []
-            if include_deleted.lower() == 'true':
-                filtering_params.append(get_delivery_info_filter('adset'))
+            adsets = []
             if self.current_bookmark:
                 filtering_params.append({'field': 'adset.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
-
-            if filtering_params:
+            if include_deleted.lower() == 'true':
+                for del_info_filt in iter_delivery_info_filter('adset'):
+                    if len(filtering_params) > 1:
+                        filtering_params.pop()
+                    filtering_params.append(del_info_filt)
+                    params.update({'filtering': filtering_params})
+                    filt_adsets = self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                    adsets.extend(filt_adsets)
+            elif filtering_params:
                 params.update({'filtering': filtering_params})
-            return self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                adsets = self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            else:
+                adsets = self.account.get_ad_sets(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            return adsets
 
         def prepare_record(ad_set):
             return ad_set.remote_read(fields=self.fields()).export_all_data()
@@ -276,14 +294,23 @@ class Campaigns(IncrementalStream):
             params = {'limit': RESULT_RETURN_LIMIT}
             include_deleted = CONFIG.get('include_deleted', 'false')
             filtering_params = []
-            if include_deleted.lower() == 'true':
-                filtering_params.append(get_delivery_info_filter('campaign'))
+            campaigns = []
             if self.current_bookmark:
                 filtering_params.append({'field': 'campaign.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
-
-            if filtering_params:
+            if include_deleted.lower() == 'true':
+                for del_info_filt in iter_delivery_info_filter('campaign'):
+                    if len(filtering_params) > 1:
+                        filtering_params.pop()
+                    filtering_params.append(del_info_filt)
+                    params.update({'filtering': filtering_params})
+                    filt_campaigns = self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                    campaigns.extend(filt_campaigns)
+            elif filtering_params:
                 params.update({'filtering': filtering_params})
-            return self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                campaigns = self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            else:
+                campaigns = self.account.get_campaigns(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            return campaigns
 
         def prepare_record(campaign):
             campaign_out = campaign.remote_read(fields=fields).export_all_data()

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -96,12 +96,10 @@ def iter_delivery_info_filter(stream_type):
         "scheduled", "inactive"]
 
     sub_list_length = 3
-    start_index = 0
-    while start_index < len(filt_values):
-        end_index = min((start_index + sub_list_length),(len(filt_values)+1))
-        filt['value'] = filt_values[start_index:end_index]
+    for i in range(0, len(filt_values), sub_list_length):
+        filt['value'] = filt_values[i:i+sub_list_length]
+        LOGGER.info(str(filt['value']))
         yield filt
-        start_index += sub_list_length
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
     def log_retry_attempt(details):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -98,7 +98,6 @@ def iter_delivery_info_filter(stream_type):
     sub_list_length = 3
     for i in range(0, len(filt_values), sub_list_length):
         filt['value'] = filt_values[i:i+sub_list_length]
-        LOGGER.info(str(filt['value']))
         yield filt
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):


### PR DESCRIPTION
This addresses an issue where users where getting errors when attempting to retrieve filtered ads/adsets/campaigns.  The bug was reported to facebook, and the engineer suggested the following:
```
We're afraid this is related to a limitation on our system - 
your filters on the delivery info is causing out of memory errors.

What you want to do is to have a smaller filter per request and make 
multiple requests. For example, instead of getting all delivery info, you 
can have 3 in a group and make 6 separate request and consolidate 
them together offline.
```
This change breaks up the filters into sets of 3 (although the sub list size can easily be changed)