### PR TITLE
Fix dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following is an example of the required configuration
 
 ### Create a properties file
 
-The properties file will indicate what streams and fields to replicate from the Facebook Marketing API. The Tap takes advantage of the Singer best practices for [schema discovery and property selection](https://github.com/singer-io/getting-started/blob/master/BEST_PRACTICES.md#schema-discovery-and-property-selection).
+The properties file will indicate what streams and fields to replicate from the Facebook Marketing API. The Tap takes advantage of the Singer best practices for [schema discovery and property selection](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#discovery-mode).
 
 ### [Optional] Create the initial state file
 


### PR DESCRIPTION
It looks like it previously linked to https://github.com/singer-io/getting-started/blob/01c5a6757847cb8c237a27e034f9306a8b547c3e/BEST_PRACTICES.md#schema-discovery-and-property-selection
