### PR TITLE
add `video_play_curve_actions` to ads_insights schemas

### DIFF
--- a/tap_facebook/schemas/ads_insights.json
+++ b/tap_facebook/schemas/ads_insights.json
@@ -14,6 +14,7 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": [
         "null",

--- a/tap_facebook/schemas/ads_insights_age_and_gender.json
+++ b/tap_facebook/schemas/ads_insights_age_and_gender.json
@@ -14,6 +14,7 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": [
         "null",

--- a/tap_facebook/schemas/ads_insights_country.json
+++ b/tap_facebook/schemas/ads_insights_country.json
@@ -14,6 +14,7 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": [
         "null",

--- a/tap_facebook/schemas/ads_insights_dma.json
+++ b/tap_facebook/schemas/ads_insights_dma.json
@@ -11,6 +11,7 @@
     "video_p50_watched_actions": { "$ref": "ads_action_stats.json" },
     "video_p75_watched_actions": { "$ref": "ads_action_stats.json" },
     "video_p100_watched_actions": { "$ref": "ads_action_stats.json" },
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": ["null", "integer"]
     },

--- a/tap_facebook/schemas/ads_insights_platform_and_device.json
+++ b/tap_facebook/schemas/ads_insights_platform_and_device.json
@@ -14,6 +14,7 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "impression_device": {
       "type": [
         "null",

--- a/tap_facebook/schemas/ads_insights_region.json
+++ b/tap_facebook/schemas/ads_insights_region.json
@@ -14,6 +14,7 @@
     "video_p50_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p75_watched_actions": {"$ref": "ads_action_stats.json"},
     "video_p100_watched_actions": {"$ref": "ads_action_stats.json"},
+    "video_play_curve_actions": {"$ref": "ads_histogram_stats.json"},
     "clicks": {
       "type": [
         "null",

--- a/tap_facebook/schemas/shared/ads_histogram_stats.json
+++ b/tap_facebook/schemas/shared/ads_histogram_stats.json
@@ -1,0 +1,32 @@
+{
+  "type": [
+    "null",
+    "array"
+  ],
+  "items": {
+    "type": [
+      "null",
+      "object"
+    ],
+    "properties": {
+      "action_type": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "value": {
+        "type": [
+          "null",
+          "array"
+        ],
+        "items": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description of change
Add `video_play_curve_actions` to ads_insights schemas

# Manual QA steps
 - Tested on cloned connection
 
# Risks
None
 
# Rollback steps
 - revert this branch
