### PR TITLE
Update pip to allow pip to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-facebook
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
+            pip install -U 'pip<19.2' setuptools
             pip install .[dev]
       - run:
           name: 'pylint'


### PR DESCRIPTION
# Description of change

Updates pip during the CircleCI execution so that it can install the tap correctly without erroring.

# Manual QA steps
 - Used `circleci local execute` to test.
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
