### PR TITLE
[PLACEHOLDER]  Update singer-python version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='tap-facebook',
           'pendulum==1.2.0',
           'facebook_business==6.0.0',
           'requests==2.20.0',
-          'singer-python==5.8.1',
+          'singer-python==5.9.1',
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change
This PR is intended to accompany the changes in https://github.com/singer-io/singer-python/pull/126. In short, Airflow 10.7 is dependent on `jsonschema >= 3.0.0`, and `singer-python` depends on `jsonschema==2.6.0`. However, as the version has not been updated yet, this PR stands to reduce later contribution efforts.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
