### PR TITLE
Fix tests: Format start_date with T and Z

### DIFF
--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -72,7 +72,7 @@ class FacebookAutomaticFields(unittest.TestCase):
         return return_value
 
     def get_properties(self):
-        return {'start_date' : '2015-03-15 00:00:00',
+        return {'start_date' : '2015-03-15T00:00:00Z',
                 'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
                 'end_date': '2015-03-16T00:00:00+00:00',
                 'insights_buffer_days': '1'

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -67,7 +67,7 @@ class FacebookBookmarks(unittest.TestCase):
         }
 
     def get_properties(self):
-        return {'start_date' : '2015-03-15 00:00:00',
+        return {'start_date' : '2015-03-15T00:00:00Z',
                 'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
                 'end_date': '2015-03-16T00:00:00+00:00',
                 'insights_buffer_days': '1'

--- a/tests/test_facebook_field_selection.py
+++ b/tests/test_facebook_field_selection.py
@@ -72,7 +72,7 @@ class FacebookFieldSelection(unittest.TestCase):
         return return_value
 
     def get_properties(self):
-        return {'start_date' : '2015-03-15 00:00:00',
+        return {'start_date' : '2015-03-15T00:00:00Z',
                 'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
                 'end_date': '2015-03-16T00:00:00+00:00',
                 'insights_buffer_days': '1'


### PR DESCRIPTION
# Description of change
Tests had a malformed start date that was missing the T and Z.

# Manual QA steps
 - Ran tap-tester
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
