### PR TITLE
Grab metadata from the object and use it in the transformer

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -615,6 +615,7 @@ def do_sync(account, catalog, state):
     for stream in streams_to_sync:
         LOGGER.info('Syncing %s, fields %s', stream.name, stream.fields())
         schema = singer.resolve_schema_references(load_schema(stream), refs)
+        metadata_map = metadata.to_map(stream.catalog_entry.metadata)
         bookmark_key = BOOKMARK_KEYS.get(stream.name)
         singer.write_schema(stream.name, schema, stream.key_properties, bookmark_key, stream.stream_alias)
 
@@ -629,7 +630,7 @@ def do_sync(account, catalog, state):
                     if 'record' in message:
                         counter.increment()
                         time_extracted = utils.now()
-                        record = transformer.transform(message['record'], schema)
+                        record = transformer.transform(message['record'], schema, metadata=metadata_map)
                         singer.write_record(stream.name, record, stream.stream_alias, time_extracted)
                     elif 'state' in message:
                         singer.write_state(message['state'])


### PR DESCRIPTION
# Description of change
This PR makes the `transformer` filter out non-selected fields.

This is in response to what seems like a Facebook change, where `account_id` is always returned- for Ad Insights Streams, for example- and we were not honoring the metadata in the catalog. So `account_id` is not selected, but it shows up in the outputted records anyway

# Manual QA steps
- Ran the tap, confirmed that `account_id` is in the message before we call the transformer
- Called the transformer with the message and confirmed that `account_id` is not removed
- Modified the transformer call to take the metadata map, and confirmed that `account_id` is removed

# Risks
 - Low, we only request the fields with selected metadata. So now we are also only emitting records with fields with selected metadata

# Rollback steps
 - revert this branch
