### PR TITLE
Fix Retry Pattern for Generators

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -110,22 +110,8 @@ def iter_delivery_info_filter(stream_type):
         yield filt
 
 def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
-    # HACK: Workaround added due to bug with Facebook prematurely deprecating 'relevance_score'
-    # Issue being tracked here: https://developers.facebook.com/support/bugs/2489592517771422
-    def is_relevance_score(exception):
-        if getattr(exception, "body", None):
-            return exception.body().get("error", {}).get("message") == '(#100) relevance_score is not valid for fields param. please check https://developers.facebook.com/docs/marketing-api/reference/ads-insights/ for all valid values'
-        else:
-            return False
-
     def log_retry_attempt(details):
         _, exception, _ = sys.exc_info()
-        if is_relevance_score(exception):
-            raise Exception("Due to a bug with Facebook prematurely deprecating 'relevance_score' that is "
-                            "not affecting all tap-facebook users in the same way, you need to "
-                            "deselect `relevance_score` from your Insights export. For further "
-                            "information, please see this Facebook bug report thread: "
-                            "https://developers.facebook.com/support/bugs/2489592517771422") from exception
         LOGGER.info(exception)
         LOGGER.info('Caught retryable error after %s tries. Waiting %s more seconds then retrying...',
                     details["tries"],
@@ -133,7 +119,7 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
 
     def should_retry_api_error(exception):
         if isinstance(exception, FacebookRequestError):
-            return exception.api_transient_error() or exception.api_error_subcode() == 99 or is_relevance_score(exception)
+            return exception.api_transient_error() or exception.api_error_subcode() == 99
         elif isinstance(exception, InsightsJobTimeout):
             return True
         return False

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -270,22 +270,28 @@ class Ads(IncrementalStream):
     key_properties = ['id', 'updated_time']
 
     def __iter__(self):
-        @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
         def do_request():
             params = {'limit': RESULT_RETURN_LIMIT}
             if self.current_bookmark:
                 params.update({'filtering': [{'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp}]})
-            yield self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+            # NB: This is needed because the iterator yielded by this
+            # function won't have the backoff, so the call to get ads
+            # should be decorated
+            backoff_get_ads = retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)(self.account.get_ads)
+            yield backoff_get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
 
-        @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
         def do_request_multiple():
             params = {'limit': RESULT_RETURN_LIMIT}
             bookmark_params = []
+            # NB: This is needed because the iterator yielded by this
+            # function won't have the backoff, so the call to get ads
+            # should be decorated
+            backoff_get_ads = retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)(self.account.get_ads)
             if self.current_bookmark:
                 bookmark_params.append({'field': 'ad.' + UPDATED_TIME_KEY, 'operator': 'GREATER_THAN', 'value': self.current_bookmark.int_timestamp})
             for del_info_filt in iter_delivery_info_filter('ad'):
                 params.update({'filtering': [del_info_filt] + bookmark_params})
-                filt_ads = self.account.get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
+                filt_ads = backoff_get_ads(fields=self.automatic_fields(), params=params) # pylint: disable=no-member
                 yield filt_ads
 
         @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)


### PR DESCRIPTION
# Description of change
It seems that at some point in the past, the tap was refactored and this caused the retry patterns to start failing to apply for certain streams.

The issue is with the generator created by `do_request_multiple`, the code returns successfully, and a generator is created, but the API request doesn't get made until the generator is iterated over. This is similar to the following example:

```
>>> def test_gen():
...     raise Exception("boom")
...     yield 1
...
>>> thing = test_gen()
>>> type(thing)
<class 'generator'>
>>> next(thing)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in test_gen
Exception: boom
```

This PR changes the functions to instead call a version of the API wrapped with the standard backoff pattern. In testing, this applied the backoff where it was not occurring before (tested over the Ads stream, and propagated the change to others affected).

- Note: This also removes the workaround code from the retry pattern that was put in for a ticket relating to a now very old version of the API that has now been marked resolved by Facebook. For Reference: https://developers.facebook.com/support/bugs/2489592517771422

# Manual QA steps
 - Ran through all 3 streams with `include_deleted` both set to "true" and "false" to confirm the final pattern
 
# Risks
 - Low, it's just retry shuffling and workaround removal. If tests pass and confirm no syntax errors, I am confident in it.
 
# Rollback steps
 - revert this branch and release new patch version
