### PR TITLE
bump version for attrs to 17.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-facebook',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_facebook'],
       install_requires=[
-          'attrs==16.3.0',
+          'attrs==17.3.0',
           'backoff==1.8.0',
           'pendulum==1.2.0',
           'facebook_business==8.0.3',


### PR DESCRIPTION
# Description of change
The current version fails of `attrs` fails with a `aiohttp` conflict. See [this issue](https://github.com/singer-io/tap-facebook/issues/108)

# Manual QA steps
 - Ran `tap-facebook` using [meltano](https://meltano.com) and successfully took live data from my personal facebook ads account into snowflake.  
 
# Risks
 - This may break features I'm unaware of that rely specifically on `attrs==16.3.0` 
 
# Rollback steps
 - revert this branch
