### PR TITLE
Remove `ads.creative.creative_id` in favor of `ads.creative.id`

### DIFF
--- a/tap_facebook/schemas/ads.json
+++ b/tap_facebook/schemas/ads.json
@@ -109,12 +109,6 @@
         "object"
       ],
       "properties": {
-        "creative_id": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
         "id": {
           "type": [
             "null",


### PR DESCRIPTION
# Description of change
`ads.creative.creative_id` is not returned by the facebook api, so remove it from the schema. `ads.creative.id` is the id of the creative on the ad.

# Manual QA steps
 - 
 
# Risks
 - Potential for customers with old versions of facebook ads in which this is returned. This field has been around since the creation of the tap.
 
# Rollback steps
 - revert this branch
