### PR TITLE
Set on_giveup in backoff to reraise Exception

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -124,12 +124,18 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
             return True
         return False
 
+    # by default, program should re-raise exceptions on giveup,
+    # or else program ends with code 0 when it failed
+    def on_giveup_handler(details):
+        raise Exception(f"Gave up! Details: {details}")
+
     return backoff.on_exception(
         backoff_type,
         exception,
         jitter=None,
         on_backoff=log_retry_attempt,
         giveup=lambda exc: not should_retry_api_error(exc),
+        on_giveup=on_giveup_handler,
         **wait_gen_kwargs
     )
 


### PR DESCRIPTION
# Description of change
Fixes #116
 
# Risks
 - programs that once relied on tap-facebook not to return exit code 1 can now fail.
 
# Rollback steps
 - revert this branch
