### PR TITLE
move cron schedule time to 4pm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 19 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
# Description of change
Changing cron time for tests. Also use v4 tap-tester image. This is to try and avoid the consistent failure during the utc midnight build where we fail to source the STITCH_API_TOKEN.

# Manual QA steps
 - None.
 
# Risks
 - None, change to scheduled test run.
 
# Rollback steps
 - revert this branch
