### PR TITLE
Add retry logic for HTTP 500 errors for AdCreatives

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -119,7 +119,7 @@ def retry_pattern(backoff_type, exception, **wait_gen_kwargs):
 
     def should_retry_api_error(exception):
         if isinstance(exception, FacebookRequestError):
-            return exception.api_transient_error() or exception.api_error_subcode() == 99
+            return exception.api_transient_error() or exception.api_error_subcode() == 99 or exception.http_status() == 500
         elif isinstance(exception, InsightsJobTimeout):
             return True
         return False

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import Mock
+from facebook_business.exceptions import FacebookRequestError
+from tap_facebook import AdCreative
+
+    
+class TestAdCreatives(unittest.TestCase):
+    """A set of unit tests to ensure that requests to get AdCreatives behave
+    as expected"""
+    def test_retries_on_500(self):
+        """`AdCreative.sync.do_request()` calls a `facebook_business` method,
+        `get_ad_creatives()`, to make a request to the API. We mock this
+        method to raise a `FacebookRequestError` with an `http_status` of
+        `500`.
+
+        We expect the tap to retry this request up to 5 times, which is
+        the current hard coded `max_tries` value.
+        """
+
+        # Create the mock and force the function to throw an error
+        mocked_account = Mock()
+        mocked_account.get_ad_creatives = Mock()
+        mocked_account.get_ad_creatives.side_effect = FacebookRequestError(
+            message='',
+            request_context={"":Mock()},
+            http_status=500,
+            http_headers=Mock(),
+            body={}
+        )
+
+        # Initialize the object and call `sync()`
+        ad_creative_object = AdCreative('', mocked_account, '', '')
+        with self.assertRaises(FacebookRequestError):
+            ad_creative_object.sync()
+        # 5 is the max tries specified in the tap    
+        self.assertEquals(5, mocked_account.get_ad_creatives.call_count )    
+        
+        

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import Mock
 # from facebook_business.exceptions import FacebookRequestError
 
-import tap_facebook
+from tap_facebook import FacebookRequestError
 from tap_facebook import AdCreative
 
     
@@ -22,7 +22,7 @@ class TestAdCreatives(unittest.TestCase):
         # Create the mock and force the function to throw an error
         mocked_account = Mock()
         mocked_account.get_ad_creatives = Mock()
-        mocked_account.get_ad_creatives.side_effect = tap_facebook.FacebookRequestError(
+        mocked_account.get_ad_creatives.side_effect = FacebookRequestError(
             message='',
             request_context={"":Mock()},
             http_status=500,
@@ -32,7 +32,7 @@ class TestAdCreatives(unittest.TestCase):
 
         # Initialize the object and call `sync()`
         ad_creative_object = AdCreative('', mocked_account, '', '')
-        with self.assertRaises(tap_facebook.FacebookRequestError):
+        with self.assertRaises(FacebookRequestError):
             ad_creative_object.sync()
         # 5 is the max tries specified in the tap    
         self.assertEquals(5, mocked_account.get_ad_creatives.call_count )    

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import Mock
-from facebook_business.exceptions import FacebookRequestError
+# from facebook_business.exceptions import FacebookRequestError
+
+import tap_facebook
 from tap_facebook import AdCreative
 
     
@@ -20,7 +22,7 @@ class TestAdCreatives(unittest.TestCase):
         # Create the mock and force the function to throw an error
         mocked_account = Mock()
         mocked_account.get_ad_creatives = Mock()
-        mocked_account.get_ad_creatives.side_effect = FacebookRequestError(
+        mocked_account.get_ad_creatives.side_effect = tap_facebook.FacebookRequestError(
             message='',
             request_context={"":Mock()},
             http_status=500,
@@ -30,7 +32,7 @@ class TestAdCreatives(unittest.TestCase):
 
         # Initialize the object and call `sync()`
         ad_creative_object = AdCreative('', mocked_account, '', '')
-        with self.assertRaises(FacebookRequestError):
+        with self.assertRaises(tap_facebook.FacebookRequestError):
             ad_creative_object.sync()
         # 5 is the max tries specified in the tap    
         self.assertEquals(5, mocked_account.get_ad_creatives.call_count )    


### PR DESCRIPTION
# Description of change
Adds to the `backoff` decorator a check for `http_status == 500`.

# Manual QA steps
 - Added a unit test
 
# Risks
 - Low risk: in case this is not really a retryable error, we end up making 4 extra requests per sync. If it is retryable, this should save more tap runs.
 
# Rollback steps
 - revert this branch and bump the version
