### PR TITLE
Add singer exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='tap-facebook',
           'pendulum==1.2.0',
           'facebook_business==8.0.3',
           'requests==2.20.0',
-          'singer-python==5.8.1',
+          'singer-python==5.10.0',
       ],
       extras_require={
           'dev': [

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -17,7 +17,7 @@ import backoff
 import singer
 import singer.metrics as metrics
 from singer import utils, metadata
-from singer import SingerDiscoveryError, SingerSyncError
+from singer import SingerConfigurationError, SingerDiscoveryError, SingerSyncError
 from singer import (transform,
                     UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING,
                     Transformer, _transform_datetime)

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -733,25 +733,29 @@ def do_discover():
 
 
 def main_impl():
-    args = utils.parse_args(REQUIRED_CONFIG_KEYS)
-    account_id = args.config['account_id']
-    access_token = args.config['access_token']
+    try:
+        args = utils.parse_args(REQUIRED_CONFIG_KEYS)
+        account_id = args.config['account_id']
+        access_token = args.config['access_token']
 
-    CONFIG.update(args.config)
+        CONFIG.update(args.config)
 
-    global RESULT_RETURN_LIMIT
-    RESULT_RETURN_LIMIT = CONFIG.get('result_return_limit', RESULT_RETURN_LIMIT)
+        global RESULT_RETURN_LIMIT
+        RESULT_RETURN_LIMIT = CONFIG.get('result_return_limit', RESULT_RETURN_LIMIT)
 
-    global API
-    API = FacebookAdsApi.init(access_token=access_token)
-    user = fb_user.User(fbid='me')
-    accounts = user.get_ad_accounts()
-    account = None
-    for acc in accounts:
-        if acc['account_id'] == account_id:
-            account = acc
-    if not account:
-        raise TapFacebookException("Couldn't find account with id {}".format(account_id))
+        global API
+        API = FacebookAdsApi.init(access_token=access_token)
+        user = fb_user.User(fbid='me')
+
+        accounts = user.get_ad_accounts()
+        account = None
+        for acc in accounts:
+            if acc['account_id'] == account_id:
+                account = acc
+        if not account:
+            raise SingerConfigurationError("Couldn't find account with id {}".format(account_id))
+    except FacebookError as fb_error:
+        raise_from(SingerConfigurationError, fb_error)
 
     if args.discover:
         try:

--- a/tests/unittests/test_tap_facebook.py
+++ b/tests/unittests/test_tap_facebook.py
@@ -1,12 +1,14 @@
 import itertools
 import unittest
+from unittest.mock import patch
 import pendulum
 import tap_facebook
 
 from tap_facebook import AdsInsights
 from singer.catalog import Catalog, CatalogEntry
 from singer.schema import Schema
-from singer.utils import strftime
+from singer.utils import strftime, parse_args
+from singer import SingerDiscoveryError, SingerSyncError
 
 class TestAdsInsights(unittest.TestCase):
 
@@ -93,6 +95,43 @@ class TestDateTimeParsing(unittest.TestCase):
         self.assertEqual(
             tap_facebook.transform_datetime_string(dt),
             expected)
+
+
+def fake_args(is_discovery):
+    from collections import namedtuple
+    fake_args = namedtuple('args', 'config discover properties state')
+
+    def wrapped_function(*args, **kwargs):
+        return fake_args({'account_id': 123,
+                          'access_token': 123},
+                         is_discovery,
+                         {'streams': []},
+                         {})
+
+    return wrapped_function
+
+def get_fake_accounts(*args, **kwargs):
+    return [{'account_id': 123}]
+
+def fake_tap_run(*args, **kwargs):
+    raise tap_facebook.FacebookError('this is a test')
+
+class TestErrorHandling(unittest.TestCase):
+
+    @patch('singer.utils.parse_args', fake_args(is_discovery=True))
+    @patch('facebook_business.adobjects.user.User.get_ad_accounts', get_fake_accounts)
+    @patch('tap_facebook.do_discover', fake_tap_run)
+    def test_discovery(self):
+        with self.assertRaises(SingerDiscoveryError):
+            tap_facebook.main()
+
+    @patch('singer.utils.parse_args', fake_args(is_discovery=False))
+    @patch('facebook_business.adobjects.user.User.get_ad_accounts', get_fake_accounts)
+    @patch('tap_facebook.do_sync', fake_tap_run)
+    def test_sync(self):
+        with self.assertRaises(SingerSyncError):
+            tap_facebook.main()
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description of change
This PR makes the tap rethrow `FacebookError`s as `Singer*Error`s.

All of the classes in [facebook_business.exceptions.py](https://github.com/facebook/facebook-python-business-sdk/blob/master/facebook_business/exceptions.py) inherit from one class, `FacebookError`. And only one of those subclasses has extra fields on it that we can extract a meaningful error message from.

# Manual QA steps
 - Added unit tests
 
# Risks
 - Low, this only affects logging
 
# Rollback steps
 - revert this branch
