### PR TITLE
changed the way we parse FacebookRequestError messages

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -118,10 +118,10 @@ def raise_from(singer_error, fb_error):
     info out of it
     """
     if isinstance(fb_error, FacebookRequestError):
-        http_method = fb_error.request_context.get('method', 'Unknown HTTP Method')
+        http_method = fb_error.request_context().get('method', 'Unknown HTTP Method')
         error_message = '{}: {} Message: {}'.format(
             http_method,
-            fb_error.status(),
+            fb_error.http_status(),
             fb_error.body().get('error', {}).get('message')
         )
     else:


### PR DESCRIPTION
# Description of change
changed the way we parse FacebookRequestError messages
this is to fix this issue: https://jira.talendforge.org/browse/TDL-393

# Manual QA steps
 - we reproduced the error that causes a `function object has no attribute get` exception
 - this is specifically a FacebookRequestError message
 - we changed the logic in the function that parses this message to parse the message correctly
 - we observed the sync error properly

- we ran all integration tests and unit tests locally
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
