### PR TITLE
Bump version to 1.11.2 to pull in latest orca with python 3.8.0 in container, but not used except for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.11.2
+  * Pull in latest orchestrator with python version 3.8.0 on container, but not used in production for tap-facebook yet
+
 ## 1.11.1
   * Modifies the way FacebookRequestError is parsed [#135](https://github.com/singer-io/tap-facebook/pull/135)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.11.1',
+      version='1.11.2',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION

# Description of change
Bump version to 1.11.2 to pull in latest orca with python 3.8.0 in container, but not used except for testing

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
