### PR TITLE
add use-a-generator to disables list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-facebook
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            pip install -U pip setuptools
             pip install .[dev]
       - run:
           name: 'pylint'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             pylint tap_facebook -d C,R,W
       - run:
-          name: 'pylint tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            pip install pylint
-            pylint tests/*.py -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring'
-      - run:
           when: always
           name: 'Unit Tests'
           command: |
@@ -34,7 +28,6 @@ jobs:
             nosetests tests/unittests
       - add_ssh_keys
       - run:
-          when: always
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
@@ -47,6 +40,12 @@ jobs:
                      --password=$SANDBOX_PASSWORD \
                      --client-id=50 \
                      tests
+      - run:
+          name: 'pylint tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            pip install pylint
+            pylint tests/*.py -d 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,duplicate-code,no-name-in-module,attribute-defined-outside-init,too-many-statements,cell-var-from-loop,too-many-public-methods,missing-docstring,use-a-generator'
       - slack/notify-on-failure:
           only_for_branches: master
 


### PR DESCRIPTION
# Description of change
Move tests-pylint step to after the integration tests step.
Remove `when: always` from integration tests step.
Update disable list for tests-pylint.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
