### PR TITLE
Add leads stream 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
     steps:
       - checkout
       - run:
@@ -51,7 +51,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 19 * * *"
           filters:
             branches:
               only:

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -793,7 +793,7 @@ def discover_schemas():
                                                key_properties=stream.key_properties))
 
         bookmark_key = BOOKMARK_KEYS.get(stream.name)
-        if bookmark_key == UPDATED_TIME_KEY:
+        if bookmark_key == UPDATED_TIME_KEY or bookmark_key == CREATED_TIME_KEY :
             mdata = metadata.write(mdata, ('properties', bookmark_key), 'inclusion', 'automatic')
 
         result['streams'].append({'stream': stream.name,

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -238,7 +238,7 @@ class BatchStream(Stream):
     def sync_batches(self, stream_objects):
         refs = load_shared_schema_refs()
         schema = singer.resolve_schema_references(self.catalog_entry.schema.to_dict(), refs)
-        transfomer = Transformer(pre_hook=transform_date_hook)
+        transformer = Transformer(pre_hook=transform_date_hook)
 
         # Create the initial batch
         api_batch = API.new_batch()

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -276,7 +276,7 @@ class AdCreative(BatchStream):
         return self.account.get_ad_creatives(params={'limit': RESULT_RETURN_LIMIT})
 
     def sync(self):
-        adcreatives = self.get_adcreatives
+        adcreatives = self.get_adcreatives()
         self.sync_batches(adcreatives)
 
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -427,7 +427,7 @@ class Leads(BatchStream):
     state = attr.ib()
 
     field_class = fb_lead.Lead.Field
-    key_properties = ['id', 'created_time']
+    key_properties = ['id']
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def get_ads(self):

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -271,7 +271,7 @@ class AdCreative(BatchStream):
     field_class = adcreative.AdCreative.Field
     key_properties = ['id']
 
-    @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
+    @retry_pattern(backoff.expo, (FacebookRequestError, TypeError), max_tries=5, factor=5)
     def get_adcreatives(self):
         return self.account.get_ad_creatives(params={'limit': RESULT_RETURN_LIMIT})
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -34,8 +34,6 @@ import facebook_business.adobjects.user as fb_user
 
 from facebook_business.exceptions import FacebookRequestError
 
-TODAY = pendulum.today()
-
 API = None
 
 INSIGHTS_MAX_WAIT_TO_START_SECONDS = 2 * 60

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -31,6 +31,7 @@ import facebook_business.adobjects.adset as adset
 import facebook_business.adobjects.campaign as fb_campaign
 import facebook_business.adobjects.adsinsights as adsinsights
 import facebook_business.adobjects.user as fb_user
+import facebook_business.adobjects.lead as fb_lead
 
 from facebook_business.exceptions import FacebookRequestError
 
@@ -53,10 +54,12 @@ STREAMS = [
     'ads_insights_platform_and_device',
     'ads_insights_region',
     'ads_insights_dma',
+    'leads',
 ]
 
 REQUIRED_CONFIG_KEYS = ['start_date', 'account_id', 'access_token']
 UPDATED_TIME_KEY = 'updated_time'
+CREATED_TIME_KEY = 'created_time'
 START_DATE_KEY = 'date_start'
 
 BOOKMARK_KEYS = {
@@ -69,6 +72,7 @@ BOOKMARK_KEYS = {
     'ads_insights_platform_and_device': START_DATE_KEY,
     'ads_insights_region': START_DATE_KEY,
     'ads_insights_dma': START_DATE_KEY,
+    'leads': CREATED_TIME_KEY,
 }
 
 LOGGER = singer.get_logger()
@@ -189,25 +193,50 @@ class IncrementalStream(Stream):
                 yield {'state': advance_bookmark(self, UPDATED_TIME_KEY, str(max_bookmark))}
 
 
-def ad_creative_success(response, stream=None):
+def batch_record_success(response, stream=None, transformer=None, schema=None):
     '''A success callback for the FB Batch endpoint used when syncing AdCreatives. Needs the stream
     to resolve schema refs and transform the successful response object.'''
-    refs = load_shared_schema_refs()
-    schema = singer.resolve_schema_references(stream.catalog_entry.schema.to_dict(), refs)
-
     rec = response.json()
-    record = Transformer(pre_hook=transform_date_hook).transform(rec, schema)
+    record = transformer.transform(rec, schema)
     singer.write_record(stream.name, record, stream.stream_alias, utils.now())
 
 
-def ad_creative_failure(response):
+def batch_record_failure(response):
     '''A failure callback for the FB Batch endpoint used when syncing AdCreatives. Raises the error
     so it fails the sync process.'''
     raise response.error()
 
 
-# AdCreative is not an interable stream as it uses the batch endpoint
-class AdCreative(Stream):
+class BatchStream(Stream):
+    def sync_batches(self, stream_objects):
+        refs = load_shared_schema_refs()
+        schema = singer.resolve_schema_references(self.catalog_entry.schema.to_dict(), refs)
+        transfomer = Transformer(pre_hook=transform_date_hook)
+
+        # Create the initial batch
+        api_batch = API.new_batch()
+        batch_count = 0
+
+        # This loop syncs minimal fb objects
+        for obj in stream_objects:
+            # Excecute and create a new batch for every 50 added
+            if batch_count % 50 == 0:
+                api_batch.execute()
+                api_batch = API.new_batch()
+
+            # Add a call to the batch with the full object
+            obj.api_get(fields=self.fields(),
+                        batch=api_batch,
+                        success=partial(batch_record_success, stream=self, transformer=transformer, schema=schema),
+                        failure=batch_record_failure)
+            batch_count += 1
+
+        # Ensure the final batch is executed
+        api_batch.execute()
+
+
+# AdCreative is not an iterable stream as it uses the batch endpoint
+class AdCreative(BatchStream):
     '''
     doc: https://developers.facebook.com/docs/marketing-api/reference/adgroup/adcreatives/
     '''
@@ -215,34 +244,13 @@ class AdCreative(Stream):
     field_class = adcreative.AdCreative.Field
     key_properties = ['id']
 
+    @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
+    def get_adcreatives(self):
+        return self.account.get_ad_creatives(params={'limit': RESULT_RETURN_LIMIT})
 
     def sync(self):
-        @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
-        def do_request():
-            return self.account.get_ad_creatives(params={'limit': RESULT_RETURN_LIMIT})
-
-        ad_creative = do_request()
-
-        # Create the initial batch
-        api_batch = API.new_batch()
-        batch_count = 0
-
-        # This loop syncs minimal AdCreative objects
-        for a in ad_creative:
-            # Excecute and create a new batch for every 50 added
-            if batch_count % 50 == 0:
-                api_batch.execute()
-                api_batch = API.new_batch()
-
-            # Add a call to the batch with the full object
-            a.api_get(fields=self.fields(),
-                      batch=api_batch,
-                      success=partial(ad_creative_success, stream=self),
-                      failure=ad_creative_failure)
-            batch_count += 1
-
-        # Ensure the final batch is executed
-        api_batch.execute()
+        adcreatives = self.get_adcreatives
+        self.sync_batches(adcreatives)
 
 
 class Ads(IncrementalStream):
@@ -386,6 +394,49 @@ class Campaigns(IncrementalStream):
 
         for message in self._iterate(campaigns, prepare_record):
             yield message
+
+@attr.s
+class Leads(BatchStream):
+    state = attr.ib()
+
+    field_class = fb_lead.Lead.Field
+    key_properties = ['id', 'created_time']
+
+    @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
+    def get_ads(self):
+        params = {'limit': RESULT_RETURN_LIMIT}
+        yield from self.account.get_ads(params=params)
+
+    @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
+    def get_leads(self, ads, start_time, previous_start_time):
+        start_time = int(start_time.timestamp()) # Get unix timestamp
+        params = {'limit': RESULT_RETURN_LIMIT,
+                  'filtering': [{'field': 'time_created',
+                                  'operator': 'GREATER_THAN',
+                                  'value': previous_start_time - 1},
+                                {'field': 'time_created',
+                                  'operator': 'LESS_THAN',
+                                  'value': start_time}]}
+        for ad in ads:
+            yield from ad.get_leads(params=params)
+
+
+    def sync(self):
+        start_time = pendulum.utcnow()
+        previous_start_time = self.state.get("bookmarks", {}).get("leads", {}).get("start_time")
+        if previous_start_time is None:
+            previous_start_time = int(pendulum.parse(CONFIG.get('start_date')).timestamp())
+
+        ads = self.get_ads()
+        leads = self.get_leads(ads, start_time, previous_start_time)
+
+        self.sync_batches(leads)
+
+        singer.write_bookmark(self.state, 'leads', 'start_time', int(start_time.timestamp()))
+        #self.state["bookmarks"]["leads"]["start_time"] = start_time
+        singer.write_state(self.state)
+
+
 
 
 ALL_ACTION_ATTRIBUTION_WINDOWS = [
@@ -590,6 +641,8 @@ def initialize_stream(account, catalog_entry, state): # pylint: disable=too-many
         return Ads(name, account, stream_alias, catalog_entry, state=state)
     elif name == 'adcreative':
         return AdCreative(name, account, stream_alias, catalog_entry)
+    elif name == 'leads':
+        return Leads(name, account, stream_alias, catalog_entry, state=state)
     else:
         raise TapFacebookException('Unknown stream {}'.format(name))
 
@@ -621,8 +674,9 @@ def do_sync(account, catalog, state):
         bookmark_key = BOOKMARK_KEYS.get(stream.name)
         singer.write_schema(stream.name, schema, stream.key_properties, bookmark_key, stream.stream_alias)
 
+
         # NB: The AdCreative stream is not an iterator
-        if stream.name == 'adcreative':
+        if stream.name in ['adcreative', 'leads']:
             stream.sync()
             continue
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -703,7 +703,7 @@ def do_sync(account, catalog, state):
 
 
         # NB: The AdCreative stream is not an iterator
-        if stream.name in ['adcreative', 'leads']:
+        if stream.name in {'adcreative', 'leads'}:
             stream.sync()
             continue
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -56,7 +56,7 @@ STREAMS = [
     'ads_insights_platform_and_device',
     'ads_insights_region',
     'ads_insights_dma',
-    'leads',
+    #'leads',
 ]
 
 REQUIRED_CONFIG_KEYS = ['start_date', 'account_id', 'access_token']

--- a/tap_facebook/schemas/leads.json
+++ b/tap_facebook/schemas/leads.json
@@ -26,7 +26,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "field_data": {
       "type": [

--- a/tap_facebook/schemas/leads.json
+++ b/tap_facebook/schemas/leads.json
@@ -4,6 +4,7 @@
     "id": {"type": ["null", "string"]},
     "ad_id": {"type": ["null", "string"]},
     "form_id": {"type": ["null", "string"]},
+    "created_time": {"type": ["null", "string"]},
     "field_data": {
       "type": ["null", "array"],
       "items": {

--- a/tap_facebook/schemas/leads.json
+++ b/tap_facebook/schemas/leads.json
@@ -1,18 +1,62 @@
 {
-  "type": ["null", "object"],
+  "type": [
+    "null",
+    "object"
+  ],
   "properties": {
-    "id": {"type": ["null", "string"]},
-    "ad_id": {"type": ["null", "string"]},
-    "form_id": {"type": ["null", "string"]},
-    "created_time": {"type": ["null", "string"]},
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "form_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created_time": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "field_data": {
-      "type": ["null", "array"],
+      "type": [
+        "null",
+        "array"
+      ],
       "items": {
-        "type": ["null", "object"],
+        "type": [
+          "null",
+          "object"
+        ],
         "properties": {
-          "name": {"type": ["null", "string"]},
-          "values": {"type": ["null", "array"],
-                     "items": {"type": ["null", "string"]}}
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "values": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
         }
       }
     }

--- a/tap_facebook/schemas/leads.json
+++ b/tap_facebook/schemas/leads.json
@@ -1,0 +1,19 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "id": {"type": ["null", "string"]},
+    "ad_id": {"type": ["null", "string"]},
+    "form_id": {"type": ["null", "string"]},
+    "field_data": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "name": {"type": ["null", "string"]},
+          "values": {"type": ["null", "array"],
+                     "items": {"type": ["null", "string"]}}
+        }
+      }
+    }
+  }
+}

--- a/tests/base.py
+++ b/tests/base.py
@@ -119,6 +119,11 @@ class FacebookBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_start"}
             },
+            "leads": {
+                self.PRIMARY_KEYS: {"id"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: set()
+            },
         }
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -122,7 +122,7 @@ class FacebookBaseTest(unittest.TestCase):
             "leads": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: set()
+                self.REPLICATION_KEYS: {"created_time"}
             },
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -119,11 +119,11 @@ class FacebookBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_start"}
             },
-            "leads": {
-                self.PRIMARY_KEYS: {"id"},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {"created_time"}
-            },
+            # "leads": {
+            #     self.PRIMARY_KEYS: {"id"},
+            #     self.REPLICATION_METHOD: self.INCREMENTAL,
+            #     self.REPLICATION_KEYS: {"created_time"}
+            # },
         }
 
 

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -64,6 +64,7 @@ class FacebookBookmarks(FacebookBaseTest):
                                for stream in self.expected_streams()}
         timedelta_by_stream['campaigns'] = [0, 1, 0]
         timedelta_by_stream['adsets'] = [0, 1, 0]
+        timedelta_by_stream['leads'] = [0, 0 , 1]
 
         stream_to_calculated_state = {stream: "" for stream in current_state['bookmarks'].keys()}
         for stream, state in current_state['bookmarks'].items():

--- a/tests/test_facebook_discovery.py
+++ b/tests/test_facebook_discovery.py
@@ -88,7 +88,7 @@ class DiscoveryTest(FacebookBaseTest):
                 failing_with_no_replication_keys = {
                     'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
                     'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights'
+                    'ads_insights_dma', 'ads_insights', 'leads'
                 }
                 if stream not in failing_with_no_replication_keys:  # BUG_1
                     # verify replication key(s) match expectations
@@ -105,7 +105,7 @@ class DiscoveryTest(FacebookBaseTest):
                 failing_with_no_replication_method = {
                     'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
                     'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights'
+                    'ads_insights_dma', 'ads_insights', 'leads'
                 }
                 if stream not in failing_with_no_replication_method:  # BUG_2
                     # verify the replication method matches our expectations

--- a/tests/test_facebook_field_selection.py
+++ b/tests/test_facebook_field_selection.py
@@ -25,7 +25,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             'ads_insights_platform_and_device',
             'ads_insights_region',
             'ads_insights_dma',
-            'leads',
+            #'leads',
         }
 
     @staticmethod
@@ -41,7 +41,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             "ads_insights_platform_and_device",
             "ads_insights_region",
             "ads_insights_dma",
-            "leads",
+            #"leads",
         }
 
     @staticmethod
@@ -57,7 +57,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             "ads_insights_platform_and_device": {"campaign_id", "adset_id", "ad_id", "date_start", "publisher_platform", "platform_position", "impression_device"},
             "ads_insights_region" :             {"campaign_id", "adset_id", "ad_id", "date_start"},
             "ads_insights_dma" :                {"campaign_id", "adset_id", "ad_id", "date_start"},
-            "leads" :                           {"id"},
+            #"leads" :                           {"id"},
         }
 
     def expected_automatic_fields(self):

--- a/tests/test_facebook_field_selection.py
+++ b/tests/test_facebook_field_selection.py
@@ -25,6 +25,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             'ads_insights_platform_and_device',
             'ads_insights_region',
             'ads_insights_dma',
+            'leads',
         }
 
     @staticmethod
@@ -40,21 +41,23 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             "ads_insights_platform_and_device",
             "ads_insights_region",
             "ads_insights_dma",
+            "leads",
         }
 
     @staticmethod
     def expected_pks():
         return {
             "ads" :                             {"id", "updated_time"},
-            "adcreative" :                      {'id'},
+            "adcreative" :                      {"id"},
             "adsets" :                          {"id", "updated_time"},
             "campaigns" :                       {"id"},
             "ads_insights" :                    {"campaign_id", "adset_id", "ad_id", "date_start"},
             "ads_insights_age_and_gender" :     {"campaign_id", "adset_id", "ad_id", "date_start", "age", "gender"},
             "ads_insights_country" :            {"campaign_id", "adset_id", "ad_id", "date_start"},
             "ads_insights_platform_and_device": {"campaign_id", "adset_id", "ad_id", "date_start", "publisher_platform", "platform_position", "impression_device"},
-            "ads_insights_region":              {"campaign_id", "adset_id", "ad_id", "date_start"},
-            "ads_insights_dma":                 {"campaign_id", "adset_id", "ad_id", "date_start"},
+            "ads_insights_region" :             {"campaign_id", "adset_id", "ad_id", "date_start"},
+            "ads_insights_dma" :                {"campaign_id", "adset_id", "ad_id", "date_start"},
+            "leads" :                           {"id"},
         }
 
     def expected_automatic_fields(self):

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -38,12 +38,12 @@ class TestAdCreative(unittest.TestCase):
         # Initialize the object and call `sync()`
         ad_creative_object = AdCreative('', mocked_account, '', '')
         with self.assertRaises(FacebookRequestError):
-            ad_creative_object.get_adcreatives()
+            ad_creative_object.sync()
         # 5 is the max tries specified in the tap
         self.assertEquals(5, mocked_account.get_ad_creatives.call_count )
 
     def test_catch_a_type_error(self):
-        """`AdCreative.sync.do_request()` calls a `facebook_buisiness` method `get_ad_creatives()`.
+        """`AdCreative.sync.do_request()` calls a `facebook_business` method `get_ad_creatives()`.
         We want to mock this to throw a `TypeError("string indices must be integers")` and assert
         that we retry this specific error.
         """

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -38,7 +38,7 @@ class TestAdCreative(unittest.TestCase):
         # Initialize the object and call `sync()`
         ad_creative_object = AdCreative('', mocked_account, '', '')
         with self.assertRaises(FacebookRequestError):
-            ad_creative_object.sync()
+            ad_creative_object.get_adcreatives()
         # 5 is the max tries specified in the tap
         self.assertEquals(5, mocked_account.get_ad_creatives.call_count )
 

--- a/tests/unittests/test_tap_facebook.py
+++ b/tests/unittests/test_tap_facebook.py
@@ -30,7 +30,7 @@ class TestAdsInsights(unittest.TestCase):
                            'until': '2017-01-07'}])
 
     def test_insights_job_params_stops(self):
-        start_date = tap_facebook.TODAY.subtract(days=2)
+        start_date = pendulum.today().subtract(days=2)
         insights = AdsInsights(
             name='insights',
             account=None,


### PR DESCRIPTION
# Description of change
Adds a leads stream which emits leads from lead ads.

The Leads stream requires several new oauth scopes. Because of this, we're shipping this pr with the stream disabled

# Manual QA steps
 - [X] got data through for leads stream
 
# Risks
 - Most of the risk involved with this change involves the need to add new oauth scopes, but if those scopes aren't added it should just break the leads stream
 
# Rollback steps
 - revert this branch
