### PR TITLE
Bump to v1.13.0, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# 1.13.0
+  * Bump API version from `v9` to `v10` [#146](https://github.com/singer-io/tap-facebook/pull/146)
+  * Add feature for AdsInsights stream: The tap will shift the start date to 37 months ago in order to fetch data from this API
+    * More info [here](https://www.facebook.com/business/help/1695754927158071?id=354406972049255)
+
 # 1.12.1
   * Increased insights job timeout to 300 seconds [#148](https://github.com/singer-io/tap-facebook/pull/148)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.12.1',
+      version='1.13.0',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change
Version bump for #146 

# 1.13.0
* Bump API version from `v9` to `v10` [#146](https://github.com/singer-io/tap-facebook/pull/146)
* Add feature for AdsInsights stream: The tap will shift the start date to 37 months ago in order to fetch data from this API

# Manual QA steps
 - See #146 
 
# Risks
 - See #146 
 
# Rollback steps
 - revert #146 and bump the version
