### PR TITLE
Add new stream: ad_insights_hourly_advertiser

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -56,6 +56,7 @@ STREAMS = [
     'ads_insights_platform_and_device',
     'ads_insights_region',
     'ads_insights_dma',
+    'ads_insights_hourly_advertiser',
     #'leads',
 ]
 
@@ -74,6 +75,7 @@ BOOKMARK_KEYS = {
     'ads_insights_platform_and_device': START_DATE_KEY,
     'ads_insights_region': START_DATE_KEY,
     'ads_insights_dma': START_DATE_KEY,
+    'ads_insights_hourly_advertiser': START_DATE_KEY,
     'leads': CREATED_TIME_KEY,
 }
 
@@ -567,7 +569,7 @@ class AdsInsights(Stream):
     # these fields are not defined in the facebook_business library
     # Sending these fields is not allowed, but they are returned by the api
     invalid_insights_fields = ['impression_device', 'publisher_platform', 'platform_position',
-                               'age', 'gender', 'country', 'placement', 'region', 'dma']
+                               'age', 'gender', 'country', 'placement', 'region', 'dma', 'hourly_stats_aggregated_by_advertiser_time_zone']
     FACEBOOK_INSIGHTS_RETENTION_PERIOD = 37 # months
 
     # pylint: disable=no-member,unsubscriptable-object,attribute-defined-outside-init
@@ -692,6 +694,8 @@ INSIGHTS_BREAKDOWNS_OPTIONS = {
                             'primary-keys': ['region']},
     'ads_insights_dma': {"breakdowns": ['dma'],
                          "primary-keys": ['dma']},
+    'ads_insights_hourly_advertiser': {'breakdowns': ['hourly_stats_aggregated_by_advertiser_time_zone'],
+                                       "primary-keys": ['hourly_stats_aggregated_by_advertiser_time_zone']},
 }
 
 

--- a/tap_facebook/schemas/ads_insights_hourly_advertiser.json
+++ b/tap_facebook/schemas/ads_insights_hourly_advertiser.json
@@ -1,0 +1,309 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "account_currency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "account_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "action_values": {"$ref": "ads_action_stats.json"},
+    "actions": {"$ref": "ads_action_stats.json"},
+    "ad_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ad_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "adset_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "attribution_setting": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "buying_type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "campaign_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_percent": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "canvas_avg_view_time": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "catalog_segment_value": {"$ref": "ads_action_stats.json"},
+    "clicks": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "conversion_values": {"$ref": "ads_action_stats.json"},
+    "conversions": {"$ref": "ads_action_stats.json"},
+    "converted_product_quantity": {"$ref": "ads_action_stats.json"},
+    "converted_product_value": {"$ref": "ads_action_stats.json"},
+    "cost_per_action_type": {"$ref": "ads_action_stats.json"},
+    "cost_per_conversion": {"$ref": "ads_action_stats.json"},
+    "cost_per_estimated_ad_recallers": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_per_inline_link_click": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_per_inline_post_engagement": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_per_outbound_click": {"$ref": "ads_action_stats.json"},
+    "cost_per_thruplay": {"$ref": "ads_action_stats.json"},
+    "cost_per_unique_action_type": {"$ref": "ads_action_stats.json"},
+    "cost_per_unique_click": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_per_unique_inline_link_click": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cost_per_unique_outbound_click": {"$ref": "ads_action_stats.json"},
+    "cpc": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpm": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "cpp": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "ctr": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_start": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "date_stop": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "engagement_rate_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recall_rate": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "estimated_ad_recallers": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "frequency": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "full_view_impressions": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "hourly_stats_aggregated_by_advertiser_time_zone": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "impressions": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "inline_link_click_ctr": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "inline_link_clicks": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "inline_post_engagement": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "instant_experience_clicks_to_open": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "instant_experience_clicks_to_start": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "instant_experience_outbound_clicks": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "mobile_app_purchase_roas": {"$ref": "ads_action_stats.json"},
+    "objective": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "optimization_goal": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "outbound_clicks": {"$ref": "ads_action_stats.json"},
+    "outbound_clicks_ctr": {"$ref": "ads_action_stats.json"},
+    "place_page_name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "purchase_roas": {"$ref": "ads_action_stats.json"},
+    "qualifying_question_qualify_answer_rate": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "quality_ranking": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "reach": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "social_spend": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "spend": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "website_ctr": {"$ref": "ads_action_stats.json"},
+    "website_purchase_roas": {"$ref": "ads_action_stats.json"}
+  }
+}

--- a/tests/base.py
+++ b/tests/base.py
@@ -119,6 +119,11 @@ class FacebookBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"date_start"}
             },
+            "ads_insights_hourly_advertiser": {
+                self.PRIMARY_KEYS: {"hourly_stats_aggregated_by_advertiser_time_zone", "campaign_id", "adset_id", "ad_id", "date_start"},
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS: {"date_start"}
+            },
             # "leads": {
             #     self.PRIMARY_KEYS: {"id"},
             #     self.REPLICATION_METHOD: self.INCREMENTAL,

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -196,7 +196,7 @@ class FacebookBookmarks(FacebookBaseTest):
 
                         # Verify the second sync records respect the previous (simulated) bookmark value
                         replication_key_value = record.get(replication_key)
-                        if stream == 'ads_insights_age_and_gender': # BUG | https://stitchdata.atlassian.net/browse/SRCE-4873
+                        if stream in {'ads_insights_age_and_gender', 'ads_insights_hourly_advertiser'}: # BUG | https://stitchdata.atlassian.net/browse/SRCE-4873
                             replication_key_value = datetime.datetime.strftime(
                                 dateutil.parser.parse(replication_key_value),
                                 self.BOOKMARK_COMPARISON_FORMAT

--- a/tests/test_facebook_discovery.py
+++ b/tests/test_facebook_discovery.py
@@ -88,7 +88,7 @@ class DiscoveryTest(FacebookBaseTest):
                 failing_with_no_replication_keys = {
                     'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
                     'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights', 'leads'
+                    'ads_insights_dma', 'ads_insights', 'leads', 'ads_insights_hourly_advertiser'
                 }
                 if stream not in failing_with_no_replication_keys:  # BUG_1
                     # verify replication key(s) match expectations
@@ -105,7 +105,7 @@ class DiscoveryTest(FacebookBaseTest):
                 failing_with_no_replication_method = {
                     'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
                     'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights', 'leads'
+                    'ads_insights_dma', 'ads_insights', 'leads', 'ads_insights_hourly_advertiser'
                 }
                 if stream not in failing_with_no_replication_method:  # BUG_2
                     # verify the replication method matches our expectations

--- a/tests/test_facebook_field_selection.py
+++ b/tests/test_facebook_field_selection.py
@@ -25,6 +25,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             'ads_insights_platform_and_device',
             'ads_insights_region',
             'ads_insights_dma',
+            "ads_insights_hourly_advertiser",
             #'leads',
         }
 
@@ -41,6 +42,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             "ads_insights_platform_and_device",
             "ads_insights_region",
             "ads_insights_dma",
+            "ads_insights_hourly_advertiser",
             #"leads",
         }
 
@@ -57,6 +59,7 @@ class FacebookFieldSelection(FacebookBaseTest):  # TODO use base.py, determine i
             "ads_insights_platform_and_device": {"campaign_id", "adset_id", "ad_id", "date_start", "publisher_platform", "platform_position", "impression_device"},
             "ads_insights_region" :             {"campaign_id", "adset_id", "ad_id", "date_start"},
             "ads_insights_dma" :                {"campaign_id", "adset_id", "ad_id", "date_start"},
+            "ads_insights_hourly_advertiser":   {"campaign_id", "adset_id", "ad_id", "date_start", "hourly_stats_aggregated_by_advertiser_time_zone"},
             #"leads" :                           {"id"},
         }
 


### PR DESCRIPTION
# Description of change
This PR adds a new Ad Insights Stream: `ads_insights_hourly_advertiser`.

## Notes

### Excluded field
- `dda_results` is a field that appears in the [Facebook Docs][FBD]. However, I did not have test data for it and did not see anything in their docs about this field. So I have excluded it from being syncable in the tap

### Breakdown Behavior

[Here's a blog post][FBP] from Facebook announcing this new breakdown.

In that link, you'll see that you can request data for multiple days at a time.

For example, your  request could contain `date_start = 2021-01-01` and `date_end = 2021-01-02`. While it's understandable that you get 48 data points out of this (one for each hour of the entire date range), that's not how this API works. It will aggregate all of the data for `01:00 - 02:00` for every day in the date range. 

Because of this behavior, we have chosen to ask for a day's worth of data at a time, hoping that allows you to aggregate however you want in your warehouse.

# Manual QA steps
- Available fields: 
    - To create the schema file here, I grabbed every field from the [Facebook SDK object][FSO] and attempted to make a report with it. After some trial and error, I found that one field would cause an error if included, `full_view_reach`, so I took it out of the request.
 
# Risks
- Low: 
    - It's a new stream. Existing integrations can safely ignore it. 
    - Anyone that wants this data should be able to run Discovery again and select it
    - There are no new scopes associated with fetching this data since it's just an `AdsInsight` Stream
 
# Rollback steps
 - revert this branch, bump the version

[FBP]: https://developers.facebook.com/ads/blog/post/2015/05/27/hourly-stats-on-insights/
[FSO]: https://github.com/facebook/facebook-python-business-sdk/blob/master/facebook_business/adobjects/adsinsights.py#L275-L409
[FBD]: https://developers.facebook.com/docs/marketing-api/insights/parameters/v10.0