### PR TITLE
Parallelize CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
             pip install .[dev]
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs
+          paths:
+            - tap-facebook
   run_pylint:
     executor: docker-executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
 
-            run-test --tap=tap-facebook << parameters.test_name >>
+            run-test --tap=tap-facebook tests/<< parameters.test_name >>
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,9 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             circleci tests glob "tests/unittests/*.py" | circleci tests split > ./tests-to-run
-            nosetests $(cat tests-to-run)
+            if [ -s ./tests-to-run ]; then
+              nosetests $(cat tests-to-run)
+            fi
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
-          name: 'Run Unit Tests'
+          name: 'Run Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
   run_pylint:
     executor: docker-executor
     steps:
+      - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
@@ -54,6 +55,7 @@ jobs:
   run_unit_tests:
     executor: docker-executor
     steps:
+      - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
             pylint tap_facebook -d C,R,W
   run_unit_tests:
     executor: docker-executor
-    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
@@ -64,9 +63,33 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            circleci tests glob "tests/unittests/*.py" | circleci tests split > ./tests-to-run
+            nosetest tests/unittests
+  run_integration_tests:
+    executor: docker-executor
+    parallelism: 2
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
+          name: 'Run Unit Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+
+            circleci tests glob "tests/*.py" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
-              nosetests $(cat tests-to-run)
+              for test_file in $(cat ./tests-to-run)
+              do
+                run-test --tap=tap-facebook \
+                         --target=target-stitch \
+                         --orchestrator=stitch-orchestrator \
+                         --email=harrison+sandboxtest@stitchdata.com \
+                         --password=$SANDBOX_PASSWORD \
+                         --client-id=50 \
+                         $test_file
+              done
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,7 @@
 version: 2.1
 
-workflows:
-  commit:
-    jobs:
-      - ensure_env:
-          context: circleci-user
-      - run_pylint:
-          context: circleci-user
-          requires:
-            - ensure_env
-      - run_unit_tests:
-          context: circleci-user
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          requires:
-            - ensure_env
+orbs:
+  slack: circleci/slack@3.4.2
 
 executors:
   docker-executor:
@@ -100,6 +85,20 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
 
-
-orbs:
-  slack: circleci/slack@3.4.2
+workflows:
+  commit:
+    jobs:
+      - ensure_env:
+          context: circleci-user
+      - run_pylint:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_unit_tests:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          requires:
+            - ensure_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,11 @@ jobs:
 
             circleci tests glob "tests/*.py" | circleci tests split > ./tests-to-run
             if [ -s ./tests-to-run ]; then
+              echo "Tests to run on this machine"
+              cat ./tests-to-run
               for test_file in $(cat ./tests-to-run)
               do
+                echo "Running $test_file"
                 run-test --tap=tap-facebook \
                          --target=target-stitch \
                          --orchestrator=stitch-orchestrator \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 
 jobs:
   ensure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,5 +137,31 @@ workflows:
             - ensure_env
       - run_integration_tests:
           context: circleci-user
+          name: "test_facebook_start_date.py"
+          test_name: "test_facebook_start_date.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_field_selection.py"
+          test_name: "test_facebook_field_selection.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_discovery.py"
+          test_name: "test_facebook_discovery.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_bookmarks.py"
+          test_name: "test_facebook_bookmarks.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_automatic_fields.py"
+          test_name: "test_facebook_automatic_fields.py"
           requires:
             - ensure_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,26 @@ workflows:
           context: circleci-user
           requires:
             - ensure_env
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - ensure_env:
+          context: circleci-user
+      - run_pylint:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_unit_tests:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          requires:
+            - ensure_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,9 @@ workflows:
           context: circleci-user
           requires:
             - build
+          filters:
+            branches:
+              only: master
   build_daily:
     jobs:
       - ensure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,8 @@ workflows:
           context: circleci-user
       - run_pylint:
           context: circleci-user
+          requires:
+            - ensure_env
 
 executors:
   docker-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ executors:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
 
 jobs:
+  build:
+    executor: docker-executor
+    steps:
+      - run: echo 'CI done'
   ensure_env:
     executor: docker-executor
     steps:
@@ -122,6 +126,11 @@ workflows:
           test_name: "test_facebook_tests_run.py"
           requires:
             - ensure_env
+      - build:
+          requires:
+            - run_pylint
+            - run_unit_tests
+            - run_integration_tests
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,6 @@ executors:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
 
-commands:
-  source-tap-venv:
-    steps:
-      - run:
-          command: |
-            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-
 jobs:
   ensure_env:
     executor: docker-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,8 @@ jobs:
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             pip install -U pip setuptools
             pip install .[dev]
+      - slack/notify-on-failure:
+          only_for_branches: master
       - persist_to_workspace:
           root: /usr/local/share/virtualenvs
           paths:
@@ -50,6 +52,8 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             pylint tap_facebook -d C,R,W
+      - slack/notify-on-failure:
+          only_for_branches: master
   run_unit_tests:
     executor: docker-executor
     steps:
@@ -61,6 +65,8 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             nosetests tests/unittests
+      - slack/notify-on-failure:
+          only_for_branches: master
   run_integration_tests:
     executor: docker-executor
     parallelism: 2
@@ -91,6 +97,8 @@ jobs:
                          $test_file
               done
             fi
+      - slack/notify-on-failure:
+          only_for_branches: master
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
 workflows:
   version: 2
-  commit: &commit_jobs
+  commit:
     jobs:
       - ensure_env:
           context: circleci-user
@@ -138,7 +138,6 @@ workflows:
             - test_facebook_automatic_fields.py
             - test_facebook_tests_run.py
   build_daily:
-    <<: *commit_jobs
     triggers:
       - schedule:
           cron: "0 6 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,10 @@ jobs:
       - slack/notify-on-failure:
           only_for_branches: master
   run_integration_tests:
+    parameters:
+      test_name:
+        type: string
     executor: docker-executor
-    parallelism: 2
     steps:
       - checkout
       - attach_workspace:
@@ -66,16 +68,7 @@ jobs:
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
 
-            circleci tests glob "tests/*.py" | circleci tests split > ./tests-to-run
-            if [ -s ./tests-to-run ]; then
-              echo "Tests to run on this machine"
-              cat ./tests-to-run
-              for test_file in $(cat ./tests-to-run)
-              do
-                echo "Running $test_file"
-                run-test --tap=tap-facebook $test_file
-              done
-            fi
+            run-test --tap=tap-facebook << parameters.test_name >>
       - slack/notify-on-failure:
           only_for_branches: master
 
@@ -95,6 +88,32 @@ workflows:
             - ensure_env
       - run_integration_tests:
           context: circleci-user
+          name: "test_facebook_start_date.py"
+          test_name: "test_facebook_start_date.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_field_selection.py"
+          test_name: "test_facebook_field_selection.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_discovery.py"
+          test_name: "test_facebook_discovery.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_bookmarks.py"
+          test_name: "test_facebook_bookmarks.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_automatic_fields.py"
+          test_name: "test_facebook_automatic_fields.py"
           requires:
             - ensure_env
   build_daily:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,62 +1,46 @@
 version: 2.1
-orbs:
-  slack: circleci/slack@3.4.2
 
-jobs:
-  build:
+workflows:
+  commit:
+    jobs:
+      - ensure_env:
+          context: circleci-user
+      - run_pylint:
+          context: circleci-user
+
+executors:
+  docker-executor:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+
+commands:
+  source-tap-venv:
+    steps:
+      - run:
+          command: |
+            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
+
+jobs:
+  ensure_env:
+    executor: docker-executor
     steps:
       - checkout
       - run:
-          name: 'Setup virtual env'
+          name: 'Setup Virtual Env'
           command: |
-            python3 -mvenv /usr/local/share/virtualenvs/tap-facebook
+            python3 -m venv /usr/local/share/virtualenvs/tap-facebook
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             pip install -U pip setuptools
             pip install .[dev]
-      - run:
-          name: 'pylint'
-          command: |
-            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            pylint tap_facebook -d C,R,W
-      - run:
-          when: always
-          name: 'Unit Tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetests tests/unittests
-      - add_ssh_keys
-      - run:
-          name: 'Integration Tests'
-          command: |
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-facebook \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests
-      - slack/notify-on-failure:
-          only_for_branches: master
+      - persist_to_workspace:
+          root: /usr/local/share/virtualenvs
+  run_pylint:
+    executor: docker-executor
+    steps:
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - source-tap-venv
+      - run: pylint tap_facebook -d C,R,W
 
-workflows:
-  version: 2
-  commit:
-    jobs:
-      - build:
-          context: circleci-user
-  build_daily:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          context: circleci-user
+orbs:
+  slack: circleci/slack@3.4.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ workflows:
           context: circleci-user
           requires:
             - ensure_env
+      - run_unit_tests:
+          context: circleci-user
+          requires:
+            - ensure_env
 
 executors:
   docker-executor:
@@ -43,8 +47,20 @@ jobs:
     steps:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
-      - source-tap-venv
-      - run: pylint tap_facebook -d C,R,W
+      - run:
+          command: |
+            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
+            pylint tap_facebook -d C,R,W
+  run_unit_tests:
+    executor: docker-executor
+    steps:
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run:
+          command: |
+            source /usr/local/share/virtualenvs/tap-facebook/bin/activate
+            nosetests tests/unittests/test_tap_facebook.py
+
 
 orbs:
   slack: circleci/slack@3.4.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run: source /usr/local/share/virtualenvs/tap-shiphero/bin/activate
+      - run: source /usr/local/share/virtualenvs/tap-facebook/bin/activate
       - run:
           name: 'Create git tag'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,12 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            - run_integration_tests
+            - test_facebook_start_date.py
+            - test_facebook_field_selection.py
+            - test_facebook_discovery.py
+            - test_facebook_bookmarks.py
+            - test_facebook_automatic_fields.py
+            - test_facebook_tests_run.py
   build_daily:
     <<: *commit_jobs
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ jobs:
             pip install twine
             python setup.py sdist --dist-dir dist
             twine upload --username $PYPI_USERNAME --password $PYPI_PASSWORD ./dist/*
+      - slack/notify-on-failure:
+          only_for_branches: master
+      - slack/notify:
+          message: ':green_circle: A new version of the tap has been tagged and released'
+
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,7 @@ workflows:
           requires:
             - ensure_env
       - build:
+          context: circleci-user
           requires:
             - run_pylint
             - run_unit_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,3 +165,9 @@ workflows:
           test_name: "test_facebook_automatic_fields.py"
           requires:
             - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_tests_run.py"
+          test_name: "test_facebook_tests_run.py"
+          requires:
+            - ensure_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,13 +73,7 @@ jobs:
               for test_file in $(cat ./tests-to-run)
               do
                 echo "Running $test_file"
-                run-test --tap=tap-facebook \
-                         --target=target-stitch \
-                         --orchestrator=stitch-orchestrator \
-                         --email=harrison+sandboxtest@stitchdata.com \
-                         --password=$SANDBOX_PASSWORD \
-                         --client-id=50 \
-                         $test_file
+                run-test --tap=tap-facebook $test_file
               done
             fi
       - slack/notify-on-failure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           only_for_branches: master
 
 workflows:
+  version: 2
   commit:
     jobs:
       - ensure_env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,19 +49,23 @@ jobs:
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
+          name: 'Run pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
             pylint tap_facebook -d C,R,W
   run_unit_tests:
     executor: docker-executor
+    parallelism: 4
     steps:
       - checkout
       - attach_workspace:
           at: /usr/local/share/virtualenvs
       - run:
+          name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetests tests/unittests/test_tap_facebook.py
+            circleci tests glob "tests/unittests/*.py" | circleci tests split > ./tests-to-run
+            nosetests $(cat tests-to-run)
 
 
 orbs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetest tests/unittests
+            nosetests tests/unittests
   run_integration_tests:
     executor: docker-executor
     parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,30 @@ jobs:
             run-test --tap=tap-facebook tests/<< parameters.test_name >>
       - slack/notify-on-failure:
           only_for_branches: master
-
+  deploy:
+    executor: docker-executor
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - '18:3e:7f:b6:39:58:d3:0f:70:54:32:d6:3e:d7:13:4e'
+      - attach_workspace:
+          at: /usr/local/share/virtualenvs
+      - run: source /usr/local/share/virtualenvs/tap-shiphero/bin/activate
+      - run:
+          name: 'Create git tag'
+          command: |
+            version=$(python setup.py --version)
+            git config user.email "stitchintegrationdev@talend.com"
+            git config user.name "${CIRCLE_USERNAME}"
+            git tag -a v"${version}" -m "version ${version}"
+            git push --tags
+      - run:
+          name: 'Build and Upload'
+          command: |
+            pip install twine
+            python setup.py sdist --dist-dir dist
+            twine upload --username $PYPI_USERNAME --password $PYPI_PASSWORD ./dist/*
 workflows:
   version: 2
   commit:
@@ -137,7 +160,69 @@ workflows:
             - test_facebook_bookmarks.py
             - test_facebook_automatic_fields.py
             - test_facebook_tests_run.py
+      - deploy:
+          context: circleci-user
+          requires:
+            - build
   build_daily:
+    jobs:
+      - ensure_env:
+          context: circleci-user
+      - run_pylint:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_unit_tests:
+          context: circleci-user
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_start_date.py"
+          test_name: "test_facebook_start_date.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_field_selection.py"
+          test_name: "test_facebook_field_selection.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_discovery.py"
+          test_name: "test_facebook_discovery.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_bookmarks.py"
+          test_name: "test_facebook_bookmarks.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_automatic_fields.py"
+          test_name: "test_facebook_automatic_fields.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_tests_run.py"
+          test_name: "test_facebook_tests_run.py"
+          requires:
+            - ensure_env
+      - build:
+          context: circleci-user
+          requires:
+            - run_pylint
+            - run_unit_tests
+            - test_facebook_start_date.py
+            - test_facebook_field_selection.py
+            - test_facebook_discovery.py
+            - test_facebook_bookmarks.py
+            - test_facebook_automatic_fields.py
+            - test_facebook_tests_run.py
     triggers:
       - schedule:
           cron: "0 6 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,56 +74,7 @@ jobs:
 
 workflows:
   version: 2
-  commit:
-    jobs:
-      - ensure_env:
-          context: circleci-user
-      - run_pylint:
-          context: circleci-user
-          requires:
-            - ensure_env
-      - run_unit_tests:
-          context: circleci-user
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_start_date.py"
-          test_name: "test_facebook_start_date.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_field_selection.py"
-          test_name: "test_facebook_field_selection.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_discovery.py"
-          test_name: "test_facebook_discovery.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_bookmarks.py"
-          test_name: "test_facebook_bookmarks.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_automatic_fields.py"
-          test_name: "test_facebook_automatic_fields.py"
-          requires:
-            - ensure_env
-  build_daily:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - master
+  commit: &commit_jobs
     jobs:
       - ensure_env:
           context: circleci-user
@@ -171,3 +122,12 @@ workflows:
           test_name: "test_facebook_tests_run.py"
           requires:
             - ensure_env
+  build_daily:
+    <<: *commit_jobs
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ workflows:
           context: circleci-user
           requires:
             - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          requires:
+            - ensure_env
 
 executors:
   docker-executor:

--- a/tests/test_facebook_tests_run.py
+++ b/tests/test_facebook_tests_run.py
@@ -3,7 +3,7 @@ import os
 potential_paths = [
     'tests/',
     '../tests/'
-    'tap-facebook-square/tests/',
+    'tap-facebook/tests/',
     '../tap-facebook/tests/',
 ]
 

--- a/tests/test_facebook_tests_run.py
+++ b/tests/test_facebook_tests_run.py
@@ -1,0 +1,48 @@
+import os
+
+potential_paths = [
+    'tests/',
+    '../tests/'
+    'tap-facebook-square/tests/',
+    '../tap-facebook/tests/',
+]
+
+
+def go_to_tests_directory():
+    for path in potential_paths:
+        if os.path.exists(path):
+            os.chdir(path)
+            return os.getcwd()
+    raise NotImplementedError("This check cannot run from {}".format(os.getcwd()))
+
+##########################################################################
+### TEST
+##########################################################################
+
+
+print("Acquiring path to tests directory.")
+cwd = go_to_tests_directory()
+
+print("Reading in filenames from tests directory.")
+files_in_dir = os.listdir(cwd)
+
+print("Dropping files that are not of the form 'test_<feature>.py'.")
+test_files_in_dir = [fn for fn in files_in_dir if fn.startswith('test_') and fn.endswith('.py')]
+
+print("Files found: {}".format(test_files_in_dir))
+
+print("Reading contents of circle config.")
+with open(cwd + "/../.circleci/config.yml", "r") as config:
+    contents = config.read()
+
+print("Parsing circle config for run blocks.")
+runs = contents.replace(' ', '').replace('\n', '').split('-run_integration_tests:')
+
+print("Verify all test files are executed in circle...")
+tests_not_found = set(test_files_in_dir)
+for filename in test_files_in_dir:
+    print("\tVerifying {} is running in circle.".format(filename))
+    if any([filename in run for run in runs]):
+        tests_not_found.remove(filename)
+assert tests_not_found == set(), "The following tests are not running in circle:\t{}".format(tests_not_found)
+print("\t SUCCESS: All tests are running in circle.")


### PR DESCRIPTION
# Summary of Changes
* Break up monolithic job into smaller jobs
* Allow the commit workflow to release a new version of the tap

# Description of change

## Smaller Jobs
This PR breaks the one `build` job into several jobs that we tell Circle to run in parallel. The workflow starts by creating the virtualenv as usual. Then we fan out and allow every test to run. There's a final `build` step that acts as a check that all of the tests were green. If any test fails, the `build` step fails and blocks a PR from merging.

## Auto Deploy
This PR also adds a new job to the `commit` workflow, `deploy`. When the version changes in the PR and the squash commit is made to master, the workflow attempts to deploy a new version. If there is a clashing git tag, the job fails and the deploy is blocked.

# Manual QA steps
 
# Risks
There's a downside to allowing the deploy job fail if `git tag` encounters a clashing tag. Our metrics in Circle will start to reflect the failing jobs
 
# Rollback steps
 - revert this branch
