### PR TITLE
TDL-9809: `forced-replication-method` missing from metadata for some streams and TDL-9872: replication keys are not specified as expected in discoverable metadata	

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetests tests/unittests
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_facebook --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - slack/notify-on-failure:
           only_for_branches: master
   run_integration_tests:

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -66,17 +66,17 @@ CREATED_TIME_KEY = 'created_time'
 START_DATE_KEY = 'date_start'
 
 BOOKMARK_KEYS = {
-    'ads': [UPDATED_TIME_KEY],
-    'adsets': [UPDATED_TIME_KEY],
-    'campaigns': [UPDATED_TIME_KEY],
-    'ads_insights': [START_DATE_KEY],
-    'ads_insights_age_and_gender': [START_DATE_KEY],
-    'ads_insights_country': [START_DATE_KEY],
-    'ads_insights_platform_and_device': [START_DATE_KEY],
-    'ads_insights_region': [START_DATE_KEY],
-    'ads_insights_dma': [START_DATE_KEY],
-    'ads_insights_hourly_advertiser': [START_DATE_KEY],
-    'leads': [CREATED_TIME_KEY],
+    'ads': UPDATED_TIME_KEY,
+    'adsets': UPDATED_TIME_KEY,
+    'campaigns': UPDATED_TIME_KEY,
+    'ads_insights': START_DATE_KEY,
+    'ads_insights_age_and_gender': START_DATE_KEY,
+    'ads_insights_country': START_DATE_KEY,
+    'ads_insights_platform_and_device': START_DATE_KEY,
+    'ads_insights_region': START_DATE_KEY,
+    'ads_insights_dma': START_DATE_KEY,
+    'ads_insights_hourly_advertiser': START_DATE_KEY,
+    'leads': CREATED_TIME_KEY,
 }
 
 LOGGER = singer.get_logger()
@@ -798,7 +798,7 @@ def discover_schemas():
 
         mdata = metadata.to_map(metadata.get_standard_metadata(schema,
                                                key_properties=stream.key_properties,
-                                               valid_replication_keys=bookmark_key if bookmark_key else None))
+                                               valid_replication_keys=[bookmark_key] if bookmark_key else None))
 
         if bookmark_key == UPDATED_TIME_KEY or bookmark_key == CREATED_TIME_KEY :
             mdata = metadata.write(mdata, ('properties', bookmark_key), 'inclusion', 'automatic')

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -66,17 +66,17 @@ CREATED_TIME_KEY = 'created_time'
 START_DATE_KEY = 'date_start'
 
 BOOKMARK_KEYS = {
-    'ads': UPDATED_TIME_KEY,
-    'adsets': UPDATED_TIME_KEY,
-    'campaigns': UPDATED_TIME_KEY,
-    'ads_insights': START_DATE_KEY,
-    'ads_insights_age_and_gender': START_DATE_KEY,
-    'ads_insights_country': START_DATE_KEY,
-    'ads_insights_platform_and_device': START_DATE_KEY,
-    'ads_insights_region': START_DATE_KEY,
-    'ads_insights_dma': START_DATE_KEY,
-    'ads_insights_hourly_advertiser': START_DATE_KEY,
-    'leads': CREATED_TIME_KEY,
+    'ads': [UPDATED_TIME_KEY],
+    'adsets': [UPDATED_TIME_KEY],
+    'campaigns': [UPDATED_TIME_KEY],
+    'ads_insights': [START_DATE_KEY],
+    'ads_insights_age_and_gender': [START_DATE_KEY],
+    'ads_insights_country': [START_DATE_KEY],
+    'ads_insights_platform_and_device': [START_DATE_KEY],
+    'ads_insights_region': [START_DATE_KEY],
+    'ads_insights_dma': [START_DATE_KEY],
+    'ads_insights_hourly_advertiser': [START_DATE_KEY],
+    'leads': [CREATED_TIME_KEY],
 }
 
 LOGGER = singer.get_logger()
@@ -794,10 +794,12 @@ def discover_schemas():
         LOGGER.info('Loading schema for %s', stream.name)
         schema = singer.resolve_schema_references(load_schema(stream), refs)
 
-        mdata = metadata.to_map(metadata.get_standard_metadata(schema,
-                                               key_properties=stream.key_properties))
-
         bookmark_key = BOOKMARK_KEYS.get(stream.name)
+
+        mdata = metadata.to_map(metadata.get_standard_metadata(schema,
+                                               key_properties=stream.key_properties,
+                                               valid_replication_keys=bookmark_key if bookmark_key else None))
+
         if bookmark_key == UPDATED_TIME_KEY or bookmark_key == CREATED_TIME_KEY :
             mdata = metadata.write(mdata, ('properties', bookmark_key), 'inclusion', 'automatic')
 

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -268,6 +268,7 @@ class AdCreative(Stream):
         api_batch.execute()
 
     key_properties = ['id']
+    replication_method = 'FULL_TABLE'
 
     @retry_pattern(backoff.expo, (FacebookRequestError, TypeError), max_tries=5, factor=5)
     def get_adcreatives(self):
@@ -284,6 +285,7 @@ class Ads(IncrementalStream):
     '''
 
     key_properties = ['id', 'updated_time']
+    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_ads(self, params):
@@ -328,6 +330,7 @@ class AdSets(IncrementalStream):
     '''
 
     key_properties = ['id', 'updated_time']
+    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_ad_sets(self, params):
@@ -369,6 +372,7 @@ class AdSets(IncrementalStream):
 class Campaigns(IncrementalStream):
 
     key_properties = ['id']
+    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_campaigns(self, params):
@@ -425,6 +429,7 @@ class Leads(Stream):
     replication_key = "created_time"
 
     key_properties = ['id']
+    replication_method = 'INCREMENTAL'
 
     def compare_lead_created_times(self, leadA, leadB):
         if leadA is None:
@@ -554,6 +559,7 @@ def advance_bookmark(stream, bookmark_key, date):
 @attr.s
 class AdsInsights(Stream):
     base_properties = ['campaign_id', 'adset_id', 'ad_id', 'date_start']
+    replication_method = 'INCREMENTAL'
 
     state = attr.ib()
     options = attr.ib()
@@ -798,6 +804,7 @@ def discover_schemas():
 
         mdata = metadata.to_map(metadata.get_standard_metadata(schema,
                                                key_properties=stream.key_properties,
+                                               replication_method=stream.replication_method,
                                                valid_replication_keys=[bookmark_key] if bookmark_key else None))
 
         if bookmark_key == UPDATED_TIME_KEY or bookmark_key == CREATED_TIME_KEY :

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -170,6 +170,7 @@ class Stream(object):
     account = attr.ib()
     stream_alias = attr.ib()
     catalog_entry = attr.ib()
+    replication_method = 'FULL_TABLE'
 
     def automatic_fields(self):
         fields = set()
@@ -200,6 +201,7 @@ class Stream(object):
 class IncrementalStream(Stream):
 
     state = attr.ib()
+    replication_method = 'INCREMENTAL'
 
     def __attrs_post_init__(self):
         self.current_bookmark = get_start(self, UPDATED_TIME_KEY)
@@ -268,7 +270,6 @@ class AdCreative(Stream):
         api_batch.execute()
 
     key_properties = ['id']
-    replication_method = 'FULL_TABLE'
 
     @retry_pattern(backoff.expo, (FacebookRequestError, TypeError), max_tries=5, factor=5)
     def get_adcreatives(self):
@@ -285,7 +286,6 @@ class Ads(IncrementalStream):
     '''
 
     key_properties = ['id', 'updated_time']
-    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_ads(self, params):
@@ -330,7 +330,6 @@ class AdSets(IncrementalStream):
     '''
 
     key_properties = ['id', 'updated_time']
-    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_ad_sets(self, params):
@@ -372,7 +371,6 @@ class AdSets(IncrementalStream):
 class Campaigns(IncrementalStream):
 
     key_properties = ['id']
-    replication_method = 'INCREMENTAL'
 
     @retry_pattern(backoff.expo, FacebookRequestError, max_tries=5, factor=5)
     def _call_get_campaigns(self, params):

--- a/tests/test_facebook_discovery.py
+++ b/tests/test_facebook_discovery.py
@@ -94,23 +94,16 @@ class DiscoveryTest(FacebookBaseTest):
                     expected_primary_keys, actual_primary_keys,
                 )
 
-                # BUG_2 | https://stitchdata.atlassian.net/browse/SRCE-4856
-                failing_with_no_replication_method = {
-                    'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
-                    'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights', 'leads', 'ads_insights_hourly_advertiser'
-                }
-                if stream not in failing_with_no_replication_method:  # BUG_2
-                    # verify the replication method matches our expectations
-                    self.assertEqual(
-                        expected_replication_method, actual_replication_method
-                    )
+                # verify the replication method matches our expectations
+                self.assertEqual(
+                    expected_replication_method, actual_replication_method
+                )
 
-                    # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
-                    if actual_replication_keys:
-                        self.assertEqual(self.INCREMENTAL, actual_replication_method)
-                    else:
-                        self.assertEqual(self.FULL_TABLE, actual_replication_method)
+                # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
+                if actual_replication_keys:
+                    self.assertEqual(self.INCREMENTAL, actual_replication_method)
+                else:
+                    self.assertEqual(self.FULL_TABLE, actual_replication_method)
 
                 # verify that primary keys and replication keys
                 # are given the inclusion of automatic in metadata.

--- a/tests/test_facebook_discovery.py
+++ b/tests/test_facebook_discovery.py
@@ -84,17 +84,10 @@ class DiscoveryTest(FacebookBaseTest):
                                 msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
                                 "\nstream_properties | {}".format(stream_properties))
 
-                # BUG_1 | https://stitchdata.atlassian.net/browse/SRCE-4855
-                failing_with_no_replication_keys = {
-                    'ads_insights_country', 'adsets', 'adcreative', 'ads', 'ads_insights_region',
-                    'campaigns', 'ads_insights_age_and_gender', 'ads_insights_platform_and_device',
-                    'ads_insights_dma', 'ads_insights', 'leads', 'ads_insights_hourly_advertiser'
-                }
-                if stream not in failing_with_no_replication_keys:  # BUG_1
-                    # verify replication key(s) match expectations
-                    self.assertSetEqual(
-                        expected_replication_keys, actual_replication_keys
-                    )
+                # verify replication key(s) match expectations
+                self.assertSetEqual(
+                    expected_replication_keys, actual_replication_keys
+                )
 
                 # verify primary key(s) match expectations
                 self.assertSetEqual(


### PR DESCRIPTION
# Description of change
TDL-9809: forced-replication-method missing from metadata for some streams
- Added replication method under `forced-replication-method`.
- Updated the discovery test to verify the scenario.

TDL-9872: replication keys are not specified as expected in discoverable metadata
- Added replication keys under `valid-replication-keys`.
- Updated the discovery test to verify the scenario.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
