### PR TITLE
TDL-7596: Add tap-tester test for attribution window

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,48 +124,48 @@ workflows:
           context: circleci-user
           requires:
             - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_start_date.py"
-      #     test_name: "test_facebook_start_date.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_field_selection.py"
-      #     test_name: "test_facebook_field_selection.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_discovery.py"
-      #     test_name: "test_facebook_discovery.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_bookmarks.py"
-      #     test_name: "test_facebook_bookmarks.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_automatic_fields.py"
-      #     test_name: "test_facebook_automatic_fields.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_tests_run.py"
-      #     test_name: "test_facebook_tests_run.py"
-      #     requires:
-      #       - ensure_env
-      # - run_integration_tests:
-      #     context: circleci-user
-      #     name: "test_facebook_attribution_window.py"
-      #     test_name: "test_facebook_attribution_window.py"
-      #     requires:
-      #       - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_start_date.py"
+          test_name: "test_facebook_start_date.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_field_selection.py"
+          test_name: "test_facebook_field_selection.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_discovery.py"
+          test_name: "test_facebook_discovery.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_bookmarks.py"
+          test_name: "test_facebook_bookmarks.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_automatic_fields.py"
+          test_name: "test_facebook_automatic_fields.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_tests_run.py"
+          test_name: "test_facebook_tests_run.py"
+          requires:
+            - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_attribution_window.py"
+          test_name: "test_facebook_attribution_window.py"
+          requires:
+            - ensure_env
       - run_integration_tests:
           context: circleci-user
           name: "test_facebook_invalid_attribution_window.py"
@@ -177,13 +177,13 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            # - test_facebook_start_date.py
-            # - test_facebook_field_selection.py
-            # - test_facebook_discovery.py
-            # - test_facebook_bookmarks.py
-            # - test_facebook_automatic_fields.py
-            # - test_facebook_tests_run.py
-            # - test_facebook_attribution_window.py
+            - test_facebook_start_date.py
+            - test_facebook_field_selection.py
+            - test_facebook_discovery.py
+            - test_facebook_bookmarks.py
+            - test_facebook_automatic_fields.py
+            - test_facebook_tests_run.py
+            - test_facebook_attribution_window.py
             - test_facebook_invalid_attribution_window.py
       - deploy:
           context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,46 +124,52 @@ workflows:
           context: circleci-user
           requires:
             - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_start_date.py"
+      #     test_name: "test_facebook_start_date.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_field_selection.py"
+      #     test_name: "test_facebook_field_selection.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_discovery.py"
+      #     test_name: "test_facebook_discovery.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_bookmarks.py"
+      #     test_name: "test_facebook_bookmarks.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_automatic_fields.py"
+      #     test_name: "test_facebook_automatic_fields.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_tests_run.py"
+      #     test_name: "test_facebook_tests_run.py"
+      #     requires:
+      #       - ensure_env
+      # - run_integration_tests:
+      #     context: circleci-user
+      #     name: "test_facebook_attribution_window.py"
+      #     test_name: "test_facebook_attribution_window.py"
+      #     requires:
+      #       - ensure_env
       - run_integration_tests:
           context: circleci-user
-          name: "test_facebook_start_date.py"
-          test_name: "test_facebook_start_date.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_field_selection.py"
-          test_name: "test_facebook_field_selection.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_discovery.py"
-          test_name: "test_facebook_discovery.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_bookmarks.py"
-          test_name: "test_facebook_bookmarks.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_automatic_fields.py"
-          test_name: "test_facebook_automatic_fields.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_tests_run.py"
-          test_name: "test_facebook_tests_run.py"
-          requires:
-            - ensure_env
-      - run_integration_tests:
-          context: circleci-user
-          name: "test_facebook_attribution_window.py"
-          test_name: "test_facebook_attribution_window.py"
+          name: "test_facebook_invalid_attribution_window.py"
+          test_name: "test_facebook_invalid_attribution_window.py"
           requires:
             - ensure_env
       - build:
@@ -171,13 +177,14 @@ workflows:
           requires:
             - run_pylint
             - run_unit_tests
-            - test_facebook_start_date.py
-            - test_facebook_field_selection.py
-            - test_facebook_discovery.py
-            - test_facebook_bookmarks.py
-            - test_facebook_automatic_fields.py
-            - test_facebook_tests_run.py
-            - test_facebook_attribution_window.py
+            # - test_facebook_start_date.py
+            # - test_facebook_field_selection.py
+            # - test_facebook_discovery.py
+            # - test_facebook_bookmarks.py
+            # - test_facebook_automatic_fields.py
+            # - test_facebook_tests_run.py
+            # - test_facebook_attribution_window.py
+            - test_facebook_invalid_attribution_window.py
       - deploy:
           context: circleci-user
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,12 @@ workflows:
           test_name: "test_facebook_tests_run.py"
           requires:
             - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_attribution_window.py"
+          test_name: "test_facebook_attribution_window.py"
+          requires:
+            - ensure_env
       - build:
           context: circleci-user
           requires:
@@ -165,6 +171,7 @@ workflows:
             - test_facebook_bookmarks.py
             - test_facebook_automatic_fields.py
             - test_facebook_tests_run.py
+            - test_facebook_attribution_window.py
       - deploy:
           context: circleci-user
           requires:
@@ -220,6 +227,12 @@ workflows:
           test_name: "test_facebook_tests_run.py"
           requires:
             - ensure_env
+      - run_integration_tests:
+          context: circleci-user
+          name: "test_facebook_attribution_window.py"
+          test_name: "test_facebook_attribution_window.py"
+          requires:
+            - ensure_env
       - build:
           context: circleci-user
           requires:
@@ -231,6 +244,7 @@ workflows:
             - test_facebook_bookmarks.py
             - test_facebook_automatic_fields.py
             - test_facebook_tests_run.py
+            - test_facebook_attribution_window.py
     triggers:
       - schedule:
           cron: "0 6 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetests tests/unittests
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_facebook --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - slack/notify-on-failure:
           only_for_branches: master
   run_integration_tests:

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -585,6 +585,9 @@ class AdsInsights(Stream):
         buffer_days = 28
         if CONFIG.get('insights_buffer_days'):
             buffer_days = int(CONFIG.get('insights_buffer_days'))
+            # attribution window should only be 1, 7 or 28
+            if buffer_days not in [1, 7, 28]:
+                raise TapFacebookException("The attribution window must be 1, 7 or 28.")
 
         buffered_start_date = start_date.subtract(days=buffer_days)
         min_start_date = pendulum.today().subtract(months=self.FACEBOOK_INSIGHTS_RETENTION_PERIOD)

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -579,17 +579,17 @@ class AdsInsights(Stream):
         if self.options.get('primary-keys'):
             self.key_properties.extend(self.options['primary-keys'])
 
+        self.buffer_days = 28
+        if CONFIG.get('insights_buffer_days'):
+            self.buffer_days = int(CONFIG.get('insights_buffer_days'))
+            # attribution window should only be 1, 7 or 28
+            if self.buffer_days not in [1, 7, 28]:
+                raise Exception("The attribution window must be 1, 7 or 28.")
+
     def job_params(self):
         start_date = get_start(self, self.bookmark_key)
 
-        buffer_days = 28
-        if CONFIG.get('insights_buffer_days'):
-            buffer_days = int(CONFIG.get('insights_buffer_days'))
-            # attribution window should only be 1, 7 or 28
-            if buffer_days not in [1, 7, 28]:
-                raise TapFacebookException("The attribution window must be 1, 7 or 28.")
-
-        buffered_start_date = start_date.subtract(days=buffer_days)
+        buffered_start_date = start_date.subtract(days=self.buffer_days)
         min_start_date = pendulum.today().subtract(months=self.FACEBOOK_INSIGHTS_RETENTION_PERIOD)
         if buffered_start_date < min_start_date:
             LOGGER.warning("%s: Start date is earlier than %s months ago, using %s instead. "

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -1,0 +1,88 @@
+import os
+
+from tap_tester import runner, connections
+
+from base import FacebookBaseTest
+
+class FacebookAttributionWindow(FacebookBaseTest):
+
+    @staticmethod
+    def name():
+        return "tap_tester_facebook_attribution_window"
+
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+        return_value = {
+            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
+            'start_date' : '2019-07-24T00:00:00Z',
+            'end_date' : '2019-07-26T00:00:00Z',
+            'insights_buffer_days': '7'
+        }
+        if original:
+            return return_value
+
+        return_value["insights_buffer_days"] = "28"
+        return_value["start_date"] = self.start_date
+        return return_value
+
+    def test_run(self):
+        self.run_test(original_props=True) # attribution window: 7
+        self.run_test(original_props=False) # attribution window: 28
+
+    def run_test(self, original_props):
+        """
+            Test to check the attribution window
+        """
+
+        # set attribution window for assertion
+        attribution_window = 7 if original_props else 28
+
+        self.start_date = '2019-07-24T00:00:00Z'
+        conn_id = connections.ensure_connection(self, original_properties=original_props)
+
+        # get start date
+        start_date = self.get_properties()['start_date']
+        # calculate start date with attribution window
+        start_date_with_attribution_window = self.timedelta_formatted(start_date, days=-attribution_window)
+
+        # 'attribution window' is only supported for 'ads_insights' streams
+        expected_streams = []
+        for stream in self.expected_streams():
+            if self.is_insight(stream):
+                expected_streams.append(stream)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # Select only the expected streams tables
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
+
+        # Run a sync job using orchestrator
+        self.run_and_verify_sync(conn_id)
+        sync_records = runner.get_records_from_target_output()
+
+        expected_replication_keys = self.expected_replication_keys()
+
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
+
+                replication_key = next(iter(expected_replication_keys[stream]))
+
+                records = [record.get('data') for record in sync_records.get(stream).get('messages')]
+
+                # check for the record is between attribution date and start date
+                is_between = False
+
+                for record in records:
+                    replication_key_value = record.get(replication_key)
+
+                    # Verify the sync records respect the (simulated) start date value
+                    self.assertGreaterEqual(self.parse_date(replication_key_value), self.parse_date(start_date_with_attribution_window),
+                                            msg="The record does not respect the attribution window.")
+
+                    # verify if the record's bookmark value is between start date and (simulated) start date value
+                    if self.parse_date(start_date_with_attribution_window) <= self.parse_date(replication_key_value) <= self.parse_date(start_date):
+                        is_between = True
+
+                    self.assertTrue(is_between, msg="No record found between start date and attribution date.")

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -7,7 +7,7 @@ from base import FacebookBaseTest
 class FacebookAttributionWindow(FacebookBaseTest):
 
     # set attribution window
-    attrubution_window = 7
+    ATTRIBUTION_WINDOW = 7
 
     @staticmethod
     def name():
@@ -19,7 +19,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
             'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
             'start_date' : '2019-07-24T00:00:00Z',
             'end_date' : '2019-07-26T00:00:00Z',
-            'insights_buffer_days': str(self.attrubution_window)
+            'insights_buffer_days': str(self.ATTRIBUTION_WINDOW)
         }
         if original:
             return return_value
@@ -28,10 +28,10 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return return_value
 
     def test_run(self):
-        self.run_test(self.attrubution_window) # attribution window: 7
+        self.run_test(self.ATTRIBUTION_WINDOW) # attribution window: 7
 
-        self.attrubution_window = 28
-        self.run_test(self.attrubution_window) # attribution window: 28
+        self.ATTRIBUTION_WINDOW = 28
+        self.run_test(self.ATTRIBUTION_WINDOW) # attribution window: 28
 
     def run_test(self, attr_window):
         """

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -30,4 +30,5 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
         conn_id = connections.ensure_connection(self)
 
-        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_mode(self, conn_id), self)
+        runner.run_check_mode(self, conn_id)
+        # self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_mode(self, conn_id), self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -31,4 +31,4 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         conn_id = connections.ensure_connection(self)
 
         # runner.run_check_mode(self, conn_id)
-        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status, self)
+        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status(conn_id), self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -1,6 +1,6 @@
 import os
 
-from tap_tester import runner, connections
+from tap_tester import runner, connections, menagerie
 
 from base import FacebookBaseTest
 
@@ -28,7 +28,8 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
             Test to verify that the error is raise when passing attribution window other than 1, 7 or 28
         """
-        self.conn_id = connections.ensure_connection(self)
-
-        # runner.run_check_mode(self, conn_id)
-        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status(self), self)
+        conn_id = connections.ensure_connection(self)
+        check_job_name = runner.run_check_mode(self, conn_id)
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        discovery_error_message = exit_status.get('discovery_error_message')
+        self.assertEquals(discovery_error_message, "The attribution window must be 1, 7 or 28.")

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -30,5 +30,5 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
         conn_id = connections.ensure_connection(self)
 
-        runner.run_check_mode(self, conn_id)
-        # self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_mode(self, conn_id), self)
+        # runner.run_check_mode(self, conn_id)
+        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status, self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -28,8 +28,13 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
             Test to verify that the error is raise when passing attribution window other than 1, 7 or 28
         """
+        # create connection
         conn_id = connections.ensure_connection(self)
+        # run check mode
         check_job_name = runner.run_check_mode(self, conn_id)
+        # get exit status
         exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        # get discovery error message
         discovery_error_message = exit_status.get('discovery_error_message')
+        # validate the error message
         self.assertEquals(discovery_error_message, "The attribution window must be 1, 7 or 28.")

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -1,0 +1,33 @@
+import os
+
+from tap_tester import runner, connections
+
+from base import FacebookBaseTest
+
+class FacebookInvalidAttributionWindow(FacebookBaseTest):
+
+    @staticmethod
+    def name():
+        return "tap_tester_facebook_invalid_attribution_window"
+
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+        return_value = {
+            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
+            'start_date' : '2019-07-24T00:00:00Z',
+            'end_date' : '2019-07-26T00:00:00Z',
+            'insights_buffer_days': '10'
+        }
+        if original:
+            return return_value
+
+        return_value["start_date"] = self.start_date
+        return return_value
+
+    def test_run(self):
+        """
+            Test to verify that the error is raise when passing attribution window other than 1, 7 or 28
+        """
+        conn_id = connections.ensure_connection(self)
+
+        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", self.run_and_verify_check_mode(conn_id), self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -30,4 +30,4 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
         conn_id = connections.ensure_connection(self)
 
-        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", self.run_and_verify_check_mode(conn_id), self)
+        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_mode(self, conn_id), self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -28,7 +28,7 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         """
             Test to verify that the error is raise when passing attribution window other than 1, 7 or 28
         """
-        conn_id = connections.ensure_connection(self)
+        self.conn_id = connections.ensure_connection(self)
 
         # runner.run_check_mode(self, conn_id)
         self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status(self), self)

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -31,4 +31,4 @@ class FacebookInvalidAttributionWindow(FacebookBaseTest):
         conn_id = connections.ensure_connection(self)
 
         # runner.run_check_mode(self, conn_id)
-        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status(conn_id), self)
+        self.assertRaisesRegex(Exception, "The attribution window must be 1, 7 or 28.", runner.run_check_job_and_check_status(self), self)

--- a/tests/unittests/test_attribution_window.py
+++ b/tests/unittests/test_attribution_window.py
@@ -1,0 +1,32 @@
+import unittest
+import tap_facebook.__init__ as tap_facebook
+
+class TestAttributionWindow(unittest.TestCase):
+    """
+        Test case to verify that proper error message is raise
+        when user enters attribution window other than 1, 7 and 28
+    """
+
+    def test_invalid_attribution_window(self):
+        error_message = None
+
+        # set config
+        tap_facebook.CONFIG = {
+            "start_date": "2019-01-01T00:00:00Z",
+            "account_id": "test_account_id",
+            "access_token": "test_access_token",
+            "insights_buffer_days": 30
+        }
+
+        # initialize 'AdsInsights' stream as attribution window is only supported in those streams
+        ads_insights_stream = tap_facebook.AdsInsights("test", "test", "test", None, {}, {})
+        try:
+            # loop over the object as '__iter__' is used
+            for data in ads_insights_stream:
+                pass
+        except tap_facebook.TapFacebookException as e:
+            # save error message for assertion
+            error_message = str(e)
+
+        # verify the error message was as expected
+        self.assertEquals(error_message, "The attribution window must be 1, 7 or 28.")

--- a/tests/unittests/test_attribution_window.py
+++ b/tests/unittests/test_attribution_window.py
@@ -18,13 +18,10 @@ class TestAttributionWindow(unittest.TestCase):
             "insights_buffer_days": 30
         }
 
-        # initialize 'AdsInsights' stream as attribution window is only supported in those streams
-        ads_insights_stream = tap_facebook.AdsInsights("test", "test", "test", None, {}, {})
         try:
-            # loop over the object as '__iter__' is used
-            for data in ads_insights_stream:
-                pass
-        except tap_facebook.TapFacebookException as e:
+            # initialize 'AdsInsights' stream as attribution window is only supported in those streams
+            tap_facebook.AdsInsights("test", "test", "test", None, {}, {})
+        except Exception as e:
             # save error message for assertion
             error_message = str(e)
 


### PR DESCRIPTION
# Description of change
TDL-7596: Add tap-tester test for attribution window

- Added test case for testing 7 day and 28 day attribution window.

NOTE: The UI does not allow the attribution window to be set except {1, 7, 28}. The tap is also working when we set an attribution window other than this.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
