### PR TITLE
TDL-9728: Stream `ads_insights_age_gender` has unexpected datatype for replication key field `date_start`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ jobs:
           name: 'Run Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-facebook/bin/activate
-            nosetests tests/unittests
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_facebook --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - slack/notify-on-failure:
           only_for_branches: master
   run_integration_tests:

--- a/tap_facebook/schemas/ads_insights_age_and_gender.json
+++ b/tap_facebook/schemas/ads_insights_age_and_gender.json
@@ -25,7 +25,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "ad_id": {
       "type": [
@@ -283,7 +284,8 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "objective": {
       "type": [

--- a/tap_facebook/schemas/ads_insights_hourly_advertiser.json
+++ b/tap_facebook/schemas/ads_insights_hourly_advertiser.json
@@ -165,13 +165,15 @@
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "date_stop": {
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "format": "date-time"
     },
     "engagement_rate_ranking": {
       "type": [

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -196,11 +196,6 @@ class FacebookBookmarks(FacebookBaseTest):
 
                         # Verify the second sync records respect the previous (simulated) bookmark value
                         replication_key_value = record.get(replication_key)
-                        if stream in {'ads_insights_age_and_gender', 'ads_insights_hourly_advertiser'}: # BUG | https://stitchdata.atlassian.net/browse/SRCE-4873
-                            replication_key_value = datetime.datetime.strftime(
-                                dateutil.parser.parse(replication_key_value),
-                                self.BOOKMARK_COMPARISON_FORMAT
-                            )
                         self.assertGreaterEqual(replication_key_value, simulated_bookmark_minus_lookback,
                                                 msg="Second sync records do not repect the previous bookmark.")
 

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -223,6 +223,13 @@ class FacebookBookmarks(FacebookBaseTest):
                         )
 
                     for record in first_sync_messages:
+                        # for "ads_insights_age_and_gender" and "ads_insights_hourly_advertiser"
+                        # verify that the "date_start" and "date_stop" is in expected format
+                        if stream in ["ads_insights_age_and_gender", "ads_insights_hourly_advertiser"]:
+                            date_start = record.get("date_start")
+                            self.assertTrue(self.is_expected_date_format(date_start))
+                            date_stop = record.get("date_stop")
+                            self.assertTrue(self.is_expected_date_format(date_stop))
 
                         # Verify the first sync bookmark value is the max replication key value for a given stream
                         replication_key_value = record.get(replication_key)

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -84,6 +84,16 @@ class FacebookBookmarks(FacebookBaseTest):
 
         return stream_to_calculated_state
 
+    # function for verifying the date format
+    def is_expected_date_format(self, date):
+        try:
+            # parse date
+            datetime.datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError:
+            # return False if date is in not expected format
+            return False
+        # return True in case of no error
+        return True
 
     def test_run(self):
         expected_streams =  self.expected_streams()
@@ -193,6 +203,13 @@ class FacebookBookmarks(FacebookBaseTest):
 
 
                     for record in second_sync_messages:
+                        # for "ads_insights_age_and_gender" and "ads_insights_hourly_advertiser"
+                        # verify that the "date_start" and "date_stop" is in expected format
+                        if stream in ["ads_insights_age_and_gender", "ads_insights_hourly_advertiser"]:
+                            date_start = record.get("date_start")
+                            self.assertTrue(self.is_expected_date_format(date_start))
+                            date_stop = record.get("date_stop")
+                            self.assertTrue(self.is_expected_date_format(date_stop))
 
                         # Verify the second sync records respect the previous (simulated) bookmark value
                         replication_key_value = record.get(replication_key)


### PR DESCRIPTION
# Description of change
TDL-9728: Stream `ads_insights_age_gender` has unexpected datatype for replication key field `date_start`

- Updated schema file of `ads_insights_age_and_gender` and `ads_insights_hourly_advertiser` and added `"format": "date-time"` to format as "2019-07-22T00:00:00.000000Z"

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
