### PR TITLE
Attribute error fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 1.18.3
+  * Facebook busines API to V13.0 [#191] (https://github.com/singer-io/tap-facebook/pull/191)
 ## 1.18.2
   * Implemented Request Timeout [#173](https://github.com/singer-io/tap-facebook/pull/173)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.18.2',
+      version='1.18.3',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -13,7 +13,7 @@ setup(name='tap-facebook',
           'attrs==17.3.0',
           'backoff==1.8.0',
           'pendulum==1.2.0',
-          'facebook_business==12.0.0',
+          'facebook_business==13.0.0',
           'requests==2.20.0',
           'singer-python==5.10.0',
       ],

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -127,10 +127,15 @@ def raise_from(singer_error, fb_error):
     """
     if isinstance(fb_error, FacebookRequestError):
         http_method = fb_error.request_context().get('method', 'Unknown HTTP Method')
+        fb_error_body = fb_error.body().get('error', {})
+        if isinstance(fb_error_body, dict):
+            fb_error_message = fb_error_body.get('message')
+        else:
+            fb_error_message = fb_error_body
         error_message = '{}: {} Message: {}'.format(
             http_method,
             fb_error.http_status(),
-            fb_error.body().get('error', {}).get('message')
+            fb_error_message
         )
     else:
         # All other facebook errors are `FacebookError`s and we handle


### PR DESCRIPTION
Ironically the tap fails when handling an error so even when this fix is deployed the error itself will will still be thrown. Seems like we're accessing a field in the error response as though it's a `dict` when it's a `str` in this case
![Screen Shot 2022-08-24 at 9 20 37 AM](https://user-images.githubusercontent.com/34848565/186429051-4b49411f-af7c-4aef-9abd-040d525f5f17.png)

