### PR TITLE
Facebook Insights error message now shows seconds

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -693,8 +693,7 @@ class AdsInsights(Stream):
                                         'This is an intermittent error and may resolve itself on subsequent queries to the Facebook API. ' +
                                         'You should deselect fields from the schema that are not necessary, ' +
                                         'as that may help improve the reliability of the Facebook API.')
-                raise InsightsJobTimeout(pretty_error_message.format(job_id,
-                                                                     INSIGHTS_MAX_WAIT_TO_FINISH_SECONDS//60))
+                raise InsightsJobTimeout(pretty_error_message.format(job_id, INSIGHTS_MAX_WAIT_TO_FINISH_SECONDS))
 
             LOGGER.info("sleeping for %d seconds until job is done", sleep_time)
             time.sleep(sleep_time)


### PR DESCRIPTION
Fixed an issue where Facebook Insights error message was showing minutes but saying seconds

# Description of change
Issue exists with error message for FB Insights download where minutes are used in seconds context. (i.e. saying "after 30 seconds" when in fact it should say "after 1800 seconds")

# Manual QA steps
 - Download insights data from Facebook and check error message
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
