### PR TITLE
Qa/fix date range in tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -373,7 +373,7 @@ class FacebookBaseTest(BaseCase):
             return dt.strftime(return_date, date_format)
 
         except ValueError:
-            return Exception("Datetime object is not of the format: {}".format(date_format))
+            raise AssertionError("Datetime object is not of the format: {}".format(date_format))
 
     ##########################################################################
     ### Tap Specific Methods

--- a/tests/base.py
+++ b/tests/base.py
@@ -365,7 +365,7 @@ class FacebookBaseTest(BaseCase):
 
         raise NotImplementedError("Tests do not account for dates of this format: {}".format(date_value))
 
-    def timedelta_formatted(self, dtime, days=0, date_format):
+    def timedelta_formatted(self, dtime, days=0, date_format=''):
         try:
             date_stripped = dt.strptime(dtime, date_format)
             return_date = date_stripped + timedelta(days=days)

--- a/tests/base.py
+++ b/tests/base.py
@@ -365,22 +365,15 @@ class FacebookBaseTest(BaseCase):
 
         raise NotImplementedError("Tests do not account for dates of this format: {}".format(date_value))
 
-    def timedelta_formatted(self, dtime, days=0):  # TODO Fix this to pass format
+    def timedelta_formatted(self, dtime, days=0, date_format):
         try:
-            date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
+            date_stripped = dt.strptime(dtime, date_format)
             return_date = date_stripped + timedelta(days=days)
 
-            return dt.strftime(return_date, self.START_DATE_FORMAT)
+            return dt.strftime(return_date, date_format)
 
         except ValueError:
-            try:
-                date_stripped = dt.strptime(dtime, self.BOOKMARK_COMPARISON_FORMAT)
-                return_date = date_stripped + timedelta(days=days)
-
-                return dt.strftime(return_date, self.BOOKMARK_COMPARISON_FORMAT)
-
-            except ValueError:
-                return Exception("Datetime object is not of the format: {}".format(self.START_DATE_FORMAT))
+            return Exception("Datetime object is not of the format: {}".format(date_format))
 
     ##########################################################################
     ### Tap Specific Methods

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,30 @@ class FacebookBaseTest(BaseCase):
 
     A bunch of shared methods that are used in tap-tester tests.
     Shared tap-specific methods (as needed).
+
+    Insights Test Data by Date Ranges
+        "ads_insights":
+          "2019-08-02T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_age_and_gender":
+          "2019-08-02T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_country":
+          "2019-08-02T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_platform_and_device":
+          "2019-08-02T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_region":
+          "2019-08-03T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_dma":
+          "2019-08-03T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+        "ads_insights_hourly_advertiser":
+          "2019-08-03T00:00:00.000000Z" -> "2019-10-30T00:00:00.000000Z"
+          "2021-04-07T00:00:00.000000Z" -> "2021-04-08T00:00:00.000000Z"
+
     """
     AUTOMATIC_FIELDS = "automatic"
     REPLICATION_KEYS = "valid-replication-keys"
@@ -45,9 +69,9 @@ class FacebookBaseTest(BaseCase):
         """Configuration properties required for the tap."""
         return_value = {
             'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-            'start_date' : '2015-03-15T00:00:00Z',
-            'end_date': '2015-03-16T00:00:00+00:00',
-            'insights_buffer_days': '1'
+            'start_date' : '2021-04-07T00:00:00Z',
+            'end_date': '2021-04-09T00:00:00Z',
+            'insights_buffer_days': '1',
         }
         if original:
             return return_value
@@ -337,7 +361,7 @@ class FacebookBaseTest(BaseCase):
 
         raise NotImplementedError("Tests do not account for dates of this format: {}".format(date_value))
 
-    def timedelta_formatted(self, dtime, days=0):
+    def timedelta_formatted(self, dtime, days=0):  # TODO Fix this to pass format
         try:
             date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
             return_date = date_stripped + timedelta(days=days)

--- a/tests/base.py
+++ b/tests/base.py
@@ -54,6 +54,7 @@ class FacebookBaseTest(BaseCase):
     BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT00:00:00+00:00"
 
     start_date = ""
+    end_date = ""
 
     @staticmethod
     def tap_name():
@@ -77,6 +78,9 @@ class FacebookBaseTest(BaseCase):
             return return_value
 
         return_value["start_date"] = self.start_date
+        if self.end_date:
+            return_value["end_date"] = self.end_date
+
         return return_value
 
     @staticmethod

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -62,7 +62,9 @@ class FacebookAttributionWindow(FacebookBaseTest):
         conn_id = connections.ensure_connection(self)
 
         # calculate start date with attribution window
-        start_date_with_attribution_window = self.timedelta_formatted(start_date, days=-attr_window)
+        start_date_with_attribution_window = self.timedelta_formatted(
+            start_date, days=-attr_window, date_format=self.START_DATE_FORMAT
+        )
 
         # Run in check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -22,8 +22,8 @@ class FacebookAutomaticFields(FacebookBaseTest):
         """Configuration properties required for the tap."""
         return_value = {
             'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-            'start_date' : '2019-07-22T00:00:00Z',
-            'end_date' : '2019-07-23T00:00:00Z',
+            'start_date' : '2021-04-08T00:00:00Z',
+            'end_date' : '2021-04-08T00:00:00Z',
             'insights_buffer_days': '1'
         }
         if original:

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -175,7 +175,8 @@ class FacebookBookmarks(FacebookBaseTest):
                     second_bookmark_value_utc = self.convert_state_to_utc(second_bookmark_value)
                     simulated_bookmark_value = new_states['bookmarks'][stream][replication_key]
                     simulated_bookmark_minus_lookback = self.timedelta_formatted(
-                        simulated_bookmark_value, days=expected_insights_buffer
+                        simulated_bookmark_value, days=expected_insights_buffer,
+                        date_format=self.BOOKMARK_COMPARISON_FORMAT
                     ) if self.is_insight(stream) else simulated_bookmark_value
 
 

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -16,22 +16,6 @@ class FacebookBookmarks(FacebookBaseTest):
     def streams_to_test(self):
         return self.expected_streams()
 
-    def get_properties(self, original: bool = True):
-        """Configuration properties required for the tap."""
-        return_value = {
-            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-            'start_date' : '2019-07-22T00:00:00Z',
-            'end_date' : '2019-07-26T00:00:00Z',
-            'insights_buffer_days': '1'
-        }
-        if original:
-            return return_value
-
-        return_value["start_date"] = self.start_date
-        return_value["end_date"] = self.end_date
-
-        return return_value
-
     @staticmethod
     def convert_state_to_utc(date_str):
         """
@@ -66,7 +50,9 @@ class FacebookBookmarks(FacebookBaseTest):
         leads     '2021-04-07T20:09:39+0000',
                   '2021-04-07T20:08:27+0000',
         """
-        timedelta_by_stream = {stream: [2,0,0]  # {stream_name: [days, hours, minutes], ...}
+        # TODO We want to move this bookmark back by some amount for insgihts streams but
+        # cannot do that unless we have at least 3 days of data. Currently we have 2.
+        timedelta_by_stream = {stream: [0,0,0]  # {stream_name: [days, hours, minutes], ...}
                                for stream in self.expected_streams()}
         timedelta_by_stream['campaigns'] = [0, 1, 0]
         timedelta_by_stream['adsets'] = [0, 1, 0]

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -20,8 +20,10 @@ class FacebookStartDateTest(FacebookBaseTest):
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
 
-        self.start_date_1 = self.get_properties().get('start_date')
-        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=1)
+        self.start_date_1 = '2021-04-07T00:00:00Z'
+        self.start_date_2 = self.timedelta_formatted(
+            self.start_date_1, days=1, date_format=self.START_DATE_FORMAT
+        )
 
         self.start_date = self.start_date_1
 
@@ -78,8 +80,12 @@ class FacebookStartDateTest(FacebookBaseTest):
                 # expected values
                 expected_primary_keys = self.expected_primary_keys()[stream]
                 expected_insights_buffer = -1 * int(self.get_properties()['insights_buffer_days'])
-                expected_start_date_1 = self.timedelta_formatted(self.start_date_1, days=expected_insights_buffer)
-                expected_start_date_2 = self.timedelta_formatted(self.start_date_2, days=expected_insights_buffer)
+                expected_start_date_1 = self.timedelta_formatted(
+                    self.start_date_1, days=expected_insights_buffer, date_format=self.START_DATE_FORMAT
+                )
+                expected_start_date_2 = self.timedelta_formatted(
+                    self.start_date_2, days=expected_insights_buffer, date_format=self.START_DATE_FORMAT
+                )
 
                 # collect information for assertions from syncs 1 & 2 base on expected values
                 record_count_sync_1 = record_count_by_stream_1.get(stream, 0)

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -17,25 +17,11 @@ class FacebookStartDateTest(FacebookBaseTest):
     def streams_to_test(self):
         return self.expected_streams()
 
-    def get_properties(self, original: bool = True):
-        """Configuration properties required for the tap."""
-        return_value = {
-            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-            'start_date' : '2019-07-22T00:00:00Z',
-            'end_date' : '2019-07-26T00:00:00Z',
-            'insights_buffer_days': '1'
-        }
-        if original:
-            return return_value
-
-        return_value["start_date"] = self.start_date
-        return return_value
-
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""
 
         self.start_date_1 = self.get_properties().get('start_date')
-        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=3)
+        self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=1)
 
         self.start_date = self.start_date_1
 

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -22,7 +22,7 @@ class FacebookStartDateTest(FacebookBaseTest):
 
         self.start_date_1 = '2021-04-07T00:00:00Z'
         self.start_date_2 = self.timedelta_formatted(
-            self.start_date_1, days=1, date_format=self.START_DATE_FORMAT
+            self.start_date_1, days=2, date_format=self.START_DATE_FORMAT
         )
 
         self.start_date = self.start_date_1


### PR DESCRIPTION
# Description of change
Adjust tests based off available test data. All tests now rely on two days of data from August 2021.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
