### PR TITLE
add `TypeError` to retryable errors for AdCreative stream

### DIFF
--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -253,7 +253,7 @@ class AdCreative(Stream):
     '''
 
     # Added retry_pattern to handle AttributeError raised from api_batch.execute() below
-    @retry_pattern(backoff.expo, (FacebookRequestError, AttributeError), max_tries=5, factor=5)
+    @retry_pattern(backoff.expo, (FacebookRequestError, TypeError, AttributeError), max_tries=5, factor=5)
     def sync_batches(self, stream_objects):
         refs = load_shared_schema_refs()
         schema = singer.resolve_schema_references(self.catalog_entry.schema.to_dict(), refs)


### PR DESCRIPTION
# Description of change
AdCreative can fail because of bad data from facebook. This change allows responses that errored to be retried.

# Manual QA steps
 - Observed the error from the request being caught and succeeding on retry before moving on the next stream.
 ```
INFO Syncing adcreative, fields {'adlabels', 'object_id', 'video_id', 'object_type', 'applink_treatment', 'account_id', 'product_set_id', 'image_url', 'instagram_permalink_url', 'object_url', 'url_tags', 'template_url', 'instagram_actor_id', 'status', 'instagram_story_id', 'link_url', 'object_story_id', 'template_url_spec', 'actor_id', 'object_story_spec', 'id', 'link_og_id', 'effective_instagram_story_id', 'call_to_action_type', 'body', 'name', 'image_crops', 'title', 'thumbnail_url', 'effective_object_story_id', 'image_hash'}
INFO Backing off sync_batches(...) for 5.0s (TypeError: string indices must be integers)
INFO string indices must be integers
INFO Caught retryable error after 1 tries. Waiting 5 more seconds then retrying...
INFO TypeError due to bad JSON response
INFO Syncing ads, fields {'updated_time', 'adlabels', 'creative', 'bid_info', 'targeting', 'created_time', 'account_id', 'conversion_specs', 'campaign_id', 'bid_type', 'tracking_specs', 'status', 'adset_id', 'id', 'bid_amount', 'name', 'effective_status', 'source_ad_id', 'recommendations', 'last_updated_by_app_id'}
INFO METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {"endpoint": "ads"}}
INFO Syncing adsets, fields {'updated_time', 'budget_remaining', 'start_time', 'adlabels', 'campaign_id', 'bid_info', 'end_time', 'created_time', 'name', 'targeting', 'lifetime_budget', 'effective_status', 'promoted_object', 'account_id', 'daily_budget', 'id'}
```
 
# Risks
 - Low. Only adding retries on failed requests.
 
# Rollback steps
 - revert this branch
