### PR TITLE
TDL-23313 Bump SDK for token url-parameter bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.18.6
+  * Bump facebook_business SDK to v17.0.2 for token param bug fix [#219](https://github.com/singer-io/tap-facebook/pull/219)
+
 ## 1.18.5
   * Bump facebook_business SDK to v16.0.2 [#213](https://github.com/singer-io/tap-facebook/pull/213)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.18.5',
+      version='1.18.6',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -13,7 +13,7 @@ setup(name='tap-facebook',
           'attrs==17.3.0',
           'backoff==1.8.0',
           'pendulum==1.2.0',
-          'facebook_business==16.0.2',
+          'facebook_business==17.0.2',
           'requests==2.20.0',
           'singer-python==5.10.0',
       ],


### PR DESCRIPTION
# Description of change
Use most recent facebook_business SDK to fix access token url param bug.

# Manual QA steps
 - Tested with cloned connection
 
# Risks
 - minimal
 
# Rollback steps
 - revert this branch
