### PR TITLE
Upgrade facebook_business SDK to v19.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.20.1
+  * Bump facebook_business SDK to v19.0.0 [#238](https://github.com/singer-io/tap-facebook/pull/238)
+
 ## 1.20.0
   * Run on python 3.11.7 [#237](https://github.com/singer-io/tap-facebook/pull/237)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.20.0',
+      version='1.20.1',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -13,7 +13,7 @@ setup(name='tap-facebook',
           'attrs==17.3.0',
           'backoff==2.2.1',
           'pendulum==1.2.0',
-          'facebook_business==17.0.2',
+          'facebook_business==19.0.0',
           'requests==2.20.0',
           'singer-python==6.0.0',
       ],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ from tap_tester.logger import LOGGER
 class TestClient():
     def __init__(self):
         self.base_url  = 'https://graph.facebook.com'
-        self.api_version = 'v18.0'
+        self.api_version = 'v19.0'
         self.account_id = os.getenv('TAP_FACEBOOK_ACCOUNT_ID')
         self.access_token  = os.getenv('TAP_FACEBOOK_ACCESS_TOKEN')
         self.account_url = f"{self.base_url}/{self.api_version}/act_{self.account_id}"


### PR DESCRIPTION
# Description of change
Bump facebook_business SDK version to [19.0.0](https://pypi.org/project/facebook-business/19.0.0/) as the current version SDK version 17.0.2 which uses v17.0 of marketing API

# Manual QA steps
 - Upgraded SDK version in local env and made sure there are no breaking changes during discovery and sync
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
