### PR TITLE
Bump facebook_business SDK to v21.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.21.0
+  * Bump facebook_business SDK to v21.0.5 [#242](https://github.com/singer-io/tap-facebook/pull/242)
+
 ## 1.20.2
   * Bump facebook_business SDK to v19.0.2 [#238](https://github.com/singer-io/tap-facebook/pull/239)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.20.2',
+      version='1.21.0',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -12,7 +12,7 @@ setup(name='tap-facebook',
       install_requires=[
           'attrs==17.3.0',
           'backoff==2.2.1',
-          'facebook_business==19.0.2',
+          'facebook_business==21.0.5',
           'pendulum==1.2.0',
           'requests==2.20.0',
           'singer-python==6.0.0',

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -2,6 +2,7 @@
 Test that with no fields selected for a stream all fields are still replicated
 """
 
+from tap_tester import LOGGER
 from tap_tester.base_suite_tests.all_fields_test import AllFieldsTest
 from base_new_frmwrk import FacebookBaseTest
 import base
@@ -224,15 +225,17 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         return "tt_facebook_all_fields_test"
 
     def streams_to_test(self):
-        # return set(self.expected_metadata().keys())
-        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-        if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-            self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "applicable EXCLUDE_STREAMS to the test.")
-            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-            # if either card is done, fail & update the test to include more streams
-            self.is_done = self.is_done or self.is_done_2
-        assert self.is_done != True, self.assert_message
+        exprected_streams = self.expected_metadata().keys()
+        self.assert_message = f"JIRA ticket has moved to done, \
+                                re-add the applicable stream to the test: {0}"
+        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+            self.assert_message.format('ads_insights_hourly_advertiser')
+        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
-        return self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
+            self.assert_message.format(self.EXCLUDE_STREAMS)
+        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
+
+        return exprected_streams

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -210,13 +210,13 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
 
     # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',
-        'ads_insights_platform_and_device',
-        'ads_insights',
-        'ads_insights_age_and_gender',
-        'ads_insights_country',
-        'ads_insights_dma',
-        'ads_insights_region'
+        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+        'ads_insights_platform_and_device', # TDL-26640
+        'ads_insights',                     # TDL-26640
+        'ads_insights_age_and_gender',      # TDL-26640
+        'ads_insights_country',             # TDL-26640
+        'ads_insights_dma',                 # TDL-26640
+        'ads_insights_region'               # TDL-26640
     }
 
     @staticmethod
@@ -224,12 +224,15 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         return "tt_facebook_all_fields_test"
 
     def streams_to_test(self):
-        #return set(self.expected_metadata().keys())
+        # return set(self.expected_metadata().keys())
         # Fail the test when the JIRA card is done to allow stream to be re-added and tested
         if self.is_done is None:
             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
             self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "ads_insights_hourly_advertiser stream to the test.")
+                                   "applicable EXCLUDE_STREAMS to the test.")
+            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+            # if either card is done, fail & update the test to include more streams
+            self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
         return self.expected_metadata().keys() - self.EXCLUDE_STREAMS

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -208,6 +208,15 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         }
     }
 
+    EXCLUDE_STREAMS = {
+        'ads_insights_hourly_advertiser',
+        'ads_insights_platform_and_device',
+        'ads_insights',
+        'ads_insights_age_and_gender',
+        'ads_insights_country',
+        'ads_insights_dma',
+        'ads_insights_region'
+    }
 
     @staticmethod
     def name():
@@ -222,4 +231,4 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
                                    "ads_insights_hourly_advertiser stream to the test.")
         assert self.is_done != True, self.assert_message
 
-        return self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        return self.expected_metadata().keys() - self.EXCLUDE_STREAMS

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -225,17 +225,17 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         return "tt_facebook_all_fields_test"
 
     def streams_to_test(self):
-        exprected_streams = self.expected_metadata().keys()
+        expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
         assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
-        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
         assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
             self.assert_message.format(self.EXCLUDE_STREAMS)
-        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 
-        return exprected_streams
+        return expected_streams

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -208,6 +208,7 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         }
     }
 
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
         'ads_insights_hourly_advertiser',
         'ads_insights_platform_and_device',

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -43,16 +43,13 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return_value["start_date"] = self.start_date
         return return_value
 
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    @base.skipUnless(base.JIRA_CLIENT.get_status_category("TDL-26640") == "done", "TDL-26640")
     def test_run(self):
         """
         For the test ad set up in facebook ads manager we see data
         on April 7th, start date is based on this data
         """
-        # TODO: https://jira.talendforge.org/browse/TDL-26640
-        if base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done':
-            LOGGER.warning("Skipping TEST! See BUG[TDL-26640]")
-            self.skipTest("Skipping TEST! See BUG[TDL-26640]")
-        
         # attrribution window = 7
         self.ATTRIBUTION_WINDOW = 7
         self.start_date = '2021-04-14T00:00:00Z'

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -1,132 +1,136 @@
-import base
-import os
+# TODO: https://jira.talendforge.org/browse/TDL-26640
+# The test is commented as all the insights streams are not having the data.
+# Please refer to the JIRA ticket for more information.
 
-from tap_tester import runner, connections
+# import base
+# import os
 
-from base import FacebookBaseTest
+# from tap_tester import runner, connections
+
+# from base import FacebookBaseTest
 
 
-class FacebookAttributionWindow(FacebookBaseTest):
+# class FacebookAttributionWindow(FacebookBaseTest):
 
-    is_done = None
+#     is_done = None
     
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
-    EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
-    }
+#     # TODO: https://jira.talendforge.org/browse/TDL-26640
+#     EXCLUDE_STREAMS = {
+#         'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+#         'ads_insights_platform_and_device', # TDL-26640
+#         'ads_insights',                     # TDL-26640
+#         'ads_insights_age_and_gender',      # TDL-26640
+#         'ads_insights_country',             # TDL-26640
+#         'ads_insights_dma',                 # TDL-26640
+#         'ads_insights_region'               # TDL-26640
+#     }
 
-    @staticmethod
-    def name():
-        return "tap_tester_facebook_attribution_window"
+#     @staticmethod
+#     def name():
+#         return "tap_tester_facebook_attribution_window"
 
-    def streams_to_test(self):
-        """ 'attribution window' is only supported for 'ads_insights' streams """
+#     def streams_to_test(self):
+#         """ 'attribution window' is only supported for 'ads_insights' streams """
 
-        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-        if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-            self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "applicable EXCLUDE_STREAMS to the test.")
-            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-            # if either card is done, fail & update the test to include more streams
-            self.is_done = self.is_done or self.is_done_2
-        assert self.is_done != True, self.assert_message
+#         # Fail the test when the JIRA card is done to allow stream to be re-added and tested
+#         if self.is_done is None:
+#             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
+#             self.assert_message = ("JIRA ticket has moved to done, re-add the "
+#                                    "applicable EXCLUDE_STREAMS to the test.")
+#             self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+#             # if either card is done, fail & update the test to include more streams
+#             self.is_done = self.is_done or self.is_done_2
+#         assert self.is_done != True, self.assert_message
 
-        # return [stream for stream in self.expected_streams() if self.is_insight(stream)]
-        return [stream for stream in self.expected_streams()
-                if self.is_insight(stream)
-                and stream != 'ads_insights_hourly_advertiser']
+#         # return [stream for stream in self.expected_streams() if self.is_insight(stream)]
+#         return [stream for stream in self.expected_streams()
+#                 if self.is_insight(stream)
+#                 and stream != 'ads_insights_hourly_advertiser']
 
-    def get_properties(self, original: bool = True):
-        """Configuration properties required for the tap."""
-        return_value = {
-            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-            'start_date': self.start_date,
-            'end_date': self.end_date,
-            'insights_buffer_days': str(self.ATTRIBUTION_WINDOW)
-        }
-        if original:
-            return return_value
+#     def get_properties(self, original: bool = True):
+#         """Configuration properties required for the tap."""
+#         return_value = {
+#             'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
+#             'start_date': self.start_date,
+#             'end_date': self.end_date,
+#             'insights_buffer_days': str(self.ATTRIBUTION_WINDOW)
+#         }
+#         if original:
+#             return return_value
 
-        return_value["start_date"] = self.start_date
-        return return_value
+#         return_value["start_date"] = self.start_date
+#         return return_value
 
-    def test_run(self):
-        """
-        For the test ad set up in facebook ads manager we see data
-        on April 7th, start date is based on this data
-        """
-        # attrribution window = 7
-        self.ATTRIBUTION_WINDOW = 7
-        self.start_date = '2021-04-14T00:00:00Z'
-        self.end_date = '2021-04-15T00:00:00Z'
-        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+#     def test_run(self):
+#         """
+#         For the test ad set up in facebook ads manager we see data
+#         on April 7th, start date is based on this data
+#         """
+#         # attrribution window = 7
+#         self.ATTRIBUTION_WINDOW = 7
+#         self.start_date = '2021-04-14T00:00:00Z'
+#         self.end_date = '2021-04-15T00:00:00Z'
+#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-        # attribution window = 28
-        self.ATTRIBUTION_WINDOW = 28
-        self.start_date = '2021-04-30T00:00:00Z'
-        self.end_date = '2021-05-01T00:00:00Z'
-        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+#         # attribution window = 28
+#         self.ATTRIBUTION_WINDOW = 28
+#         self.start_date = '2021-04-30T00:00:00Z'
+#         self.end_date = '2021-05-01T00:00:00Z'
+#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-        # attribution window = 1
-        self.ATTRIBUTION_WINDOW = 1
-        self.start_date = '2021-04-08T00:00:00Z'
-        self.end_date = '2021-04-09T00:00:00Z'
-        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+#         # attribution window = 1
+#         self.ATTRIBUTION_WINDOW = 1
+#         self.start_date = '2021-04-08T00:00:00Z'
+#         self.end_date = '2021-04-09T00:00:00Z'
+#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-    def run_test(self, attr_window, start_date, end_date):
-        """
-            Test to check the attribution window
-        """
+#     def run_test(self, attr_window, start_date, end_date):
+#         """
+#             Test to check the attribution window
+#         """
 
-        expected_streams = self.streams_to_test()
+#         expected_streams = self.streams_to_test()
 
-        conn_id = connections.ensure_connection(self)
+#         conn_id = connections.ensure_connection(self)
 
-        # calculate start date with attribution window
-        start_date_with_attribution_window = self.timedelta_formatted(
-            start_date, days=-attr_window, date_format=self.START_DATE_FORMAT
-        )
+#         # calculate start date with attribution window
+#         start_date_with_attribution_window = self.timedelta_formatted(
+#             start_date, days=-attr_window, date_format=self.START_DATE_FORMAT
+#         )
 
-        # Run in check mode
-        found_catalogs = self.run_and_verify_check_mode(conn_id)
+#         # Run in check mode
+#         found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-        # Select only the expected streams tables
-        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
-        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
+#         # Select only the expected streams tables
+#         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+#         self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
 
-        # Run a sync job using orchestrator
-        self.run_and_verify_sync(conn_id)
-        sync_records = runner.get_records_from_target_output()
+#         # Run a sync job using orchestrator
+#         self.run_and_verify_sync(conn_id)
+#         sync_records = runner.get_records_from_target_output()
 
-        expected_replication_keys = self.expected_replication_keys()
+#         expected_replication_keys = self.expected_replication_keys()
 
-        for stream in expected_streams:
-            with self.subTest(stream=stream):
+#         for stream in expected_streams:
+#             with self.subTest(stream=stream):
 
-                replication_key = next(iter(expected_replication_keys[stream]))
+#                 replication_key = next(iter(expected_replication_keys[stream]))
 
-                # get records
-                records = [record.get('data') for record in sync_records.get(stream).get('messages')]
+#                 # get records
+#                 records = [record.get('data') for record in sync_records.get(stream).get('messages')]
 
-                # check for the record is between attribution date and start date
-                is_between = False
+#                 # check for the record is between attribution date and start date
+#                 is_between = False
 
-                for record in records:
-                    replication_key_value = record.get(replication_key)
+#                 for record in records:
+#                     replication_key_value = record.get(replication_key)
 
-                    # Verify the sync records respect the attribution window
-                    self.assertGreaterEqual(self.parse_date(replication_key_value), self.parse_date(start_date_with_attribution_window),
-                                            msg="The record does not respect the attribution window.")
+#                     # Verify the sync records respect the attribution window
+#                     self.assertGreaterEqual(self.parse_date(replication_key_value), self.parse_date(start_date_with_attribution_window),
+#                                             msg="The record does not respect the attribution window.")
 
-                    # verify if the record's bookmark value is between start date and attribution window
-                    if self.parse_date(start_date_with_attribution_window) <= self.parse_date(replication_key_value) <= self.parse_date(start_date):
-                        is_between = True
+#                     # verify if the record's bookmark value is between start date and attribution window
+#                     if self.parse_date(start_date_with_attribution_window) <= self.parse_date(replication_key_value) <= self.parse_date(start_date):
+#                         is_between = True
 
-                    self.assertTrue(is_between)
+#                     self.assertTrue(is_between)

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -1,136 +1,123 @@
-# TODO: https://jira.talendforge.org/browse/TDL-26640
-# The test is commented as all the insights streams are not having the data.
-# Please refer to the JIRA ticket for more information.
+import base
+import os
 
-# import base
-# import os
+from tap_tester import runner, connections
 
-# from tap_tester import runner, connections
-
-# from base import FacebookBaseTest
+from base import FacebookBaseTest, LOGGER
 
 
-# class FacebookAttributionWindow(FacebookBaseTest):
+class FacebookAttributionWindow(FacebookBaseTest):
 
-#     is_done = None
-    
-#     # TODO: https://jira.talendforge.org/browse/TDL-26640
-#     EXCLUDE_STREAMS = {
-#         'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-#         'ads_insights_platform_and_device', # TDL-26640
-#         'ads_insights',                     # TDL-26640
-#         'ads_insights_age_and_gender',      # TDL-26640
-#         'ads_insights_country',             # TDL-26640
-#         'ads_insights_dma',                 # TDL-26640
-#         'ads_insights_region'               # TDL-26640
-#     }
+    is_done = None
 
-#     @staticmethod
-#     def name():
-#         return "tap_tester_facebook_attribution_window"
+    @staticmethod
+    def name():
+        return "tap_tester_facebook_attribution_window"
 
-#     def streams_to_test(self):
-#         """ 'attribution window' is only supported for 'ads_insights' streams """
+    def streams_to_test(self):
+        """ 'attribution window' is only supported for 'ads_insights' streams """
 
-#         # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-#         if self.is_done is None:
-#             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-#             self.assert_message = ("JIRA ticket has moved to done, re-add the "
-#                                    "applicable EXCLUDE_STREAMS to the test.")
-#             self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-#             # if either card is done, fail & update the test to include more streams
-#             self.is_done = self.is_done or self.is_done_2
-#         assert self.is_done != True, self.assert_message
+        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
+        if self.is_done is None:
+            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
+            self.assert_message = ("JIRA ticket has moved to done, re-add the "
+                                   "ads_insights_hourly_advertiser stream to the test.")
+        assert self.is_done != True, self.assert_message
 
-#         # return [stream for stream in self.expected_streams() if self.is_insight(stream)]
-#         return [stream for stream in self.expected_streams()
-#                 if self.is_insight(stream)
-#                 and stream != 'ads_insights_hourly_advertiser']
+        # return [stream for stream in self.expected_streams() if self.is_insight(stream)]
+        return [stream for stream in self.expected_streams()
+                if self.is_insight(stream)
+                and stream != 'ads_insights_hourly_advertiser']
 
-#     def get_properties(self, original: bool = True):
-#         """Configuration properties required for the tap."""
-#         return_value = {
-#             'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
-#             'start_date': self.start_date,
-#             'end_date': self.end_date,
-#             'insights_buffer_days': str(self.ATTRIBUTION_WINDOW)
-#         }
-#         if original:
-#             return return_value
+    def get_properties(self, original: bool = True):
+        """Configuration properties required for the tap."""
+        return_value = {
+            'account_id': os.getenv('TAP_FACEBOOK_ACCOUNT_ID'),
+            'start_date': self.start_date,
+            'end_date': self.end_date,
+            'insights_buffer_days': str(self.ATTRIBUTION_WINDOW)
+        }
+        if original:
+            return return_value
 
-#         return_value["start_date"] = self.start_date
-#         return return_value
+        return_value["start_date"] = self.start_date
+        return return_value
 
-#     def test_run(self):
-#         """
-#         For the test ad set up in facebook ads manager we see data
-#         on April 7th, start date is based on this data
-#         """
-#         # attrribution window = 7
-#         self.ATTRIBUTION_WINDOW = 7
-#         self.start_date = '2021-04-14T00:00:00Z'
-#         self.end_date = '2021-04-15T00:00:00Z'
-#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+    def test_run(self):
+        """
+        For the test ad set up in facebook ads manager we see data
+        on April 7th, start date is based on this data
+        """
+        # TODO: https://jira.talendforge.org/browse/TDL-26640
+        if base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done':
+            LOGGER.warning("Skipping TEST! See BUG[TDL-26640]")
+            self.skipTest("Skipping TEST! See BUG[TDL-26640]")
+        
+        # attrribution window = 7
+        self.ATTRIBUTION_WINDOW = 7
+        self.start_date = '2021-04-14T00:00:00Z'
+        self.end_date = '2021-04-15T00:00:00Z'
+        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-#         # attribution window = 28
-#         self.ATTRIBUTION_WINDOW = 28
-#         self.start_date = '2021-04-30T00:00:00Z'
-#         self.end_date = '2021-05-01T00:00:00Z'
-#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+        # attribution window = 28
+        self.ATTRIBUTION_WINDOW = 28
+        self.start_date = '2021-04-30T00:00:00Z'
+        self.end_date = '2021-05-01T00:00:00Z'
+        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-#         # attribution window = 1
-#         self.ATTRIBUTION_WINDOW = 1
-#         self.start_date = '2021-04-08T00:00:00Z'
-#         self.end_date = '2021-04-09T00:00:00Z'
-#         self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
+        # attribution window = 1
+        self.ATTRIBUTION_WINDOW = 1
+        self.start_date = '2021-04-08T00:00:00Z'
+        self.end_date = '2021-04-09T00:00:00Z'
+        self.run_test(self.ATTRIBUTION_WINDOW, self.start_date, self.end_date)
 
-#     def run_test(self, attr_window, start_date, end_date):
-#         """
-#             Test to check the attribution window
-#         """
+    def run_test(self, attr_window, start_date, end_date):
+        """
+            Test to check the attribution window
+        """
 
-#         expected_streams = self.streams_to_test()
+        expected_streams = self.streams_to_test()
 
-#         conn_id = connections.ensure_connection(self)
+        conn_id = connections.ensure_connection(self)
 
-#         # calculate start date with attribution window
-#         start_date_with_attribution_window = self.timedelta_formatted(
-#             start_date, days=-attr_window, date_format=self.START_DATE_FORMAT
-#         )
+        # calculate start date with attribution window
+        start_date_with_attribution_window = self.timedelta_formatted(
+            start_date, days=-attr_window, date_format=self.START_DATE_FORMAT
+        )
 
-#         # Run in check mode
-#         found_catalogs = self.run_and_verify_check_mode(conn_id)
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
 
-#         # Select only the expected streams tables
-#         catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
-#         self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
+        # Select only the expected streams tables
+        catalog_entries = [ce for ce in found_catalogs if ce['tap_stream_id'] in expected_streams]
+        self.perform_and_verify_table_and_field_selection(conn_id, catalog_entries, select_all_fields=True)
 
-#         # Run a sync job using orchestrator
-#         self.run_and_verify_sync(conn_id)
-#         sync_records = runner.get_records_from_target_output()
+        # Run a sync job using orchestrator
+        self.run_and_verify_sync(conn_id)
+        sync_records = runner.get_records_from_target_output()
 
-#         expected_replication_keys = self.expected_replication_keys()
+        expected_replication_keys = self.expected_replication_keys()
 
-#         for stream in expected_streams:
-#             with self.subTest(stream=stream):
+        for stream in expected_streams:
+            with self.subTest(stream=stream):
 
-#                 replication_key = next(iter(expected_replication_keys[stream]))
+                replication_key = next(iter(expected_replication_keys[stream]))
 
-#                 # get records
-#                 records = [record.get('data') for record in sync_records.get(stream).get('messages')]
+                # get records
+                records = [record.get('data') for record in sync_records.get(stream).get('messages')]
 
-#                 # check for the record is between attribution date and start date
-#                 is_between = False
+                # check for the record is between attribution date and start date
+                is_between = False
 
-#                 for record in records:
-#                     replication_key_value = record.get(replication_key)
+                for record in records:
+                    replication_key_value = record.get(replication_key)
 
-#                     # Verify the sync records respect the attribution window
-#                     self.assertGreaterEqual(self.parse_date(replication_key_value), self.parse_date(start_date_with_attribution_window),
-#                                             msg="The record does not respect the attribution window.")
+                    # Verify the sync records respect the attribution window
+                    self.assertGreaterEqual(self.parse_date(replication_key_value), self.parse_date(start_date_with_attribution_window),
+                                            msg="The record does not respect the attribution window.")
 
-#                     # verify if the record's bookmark value is between start date and attribution window
-#                     if self.parse_date(start_date_with_attribution_window) <= self.parse_date(replication_key_value) <= self.parse_date(start_date):
-#                         is_between = True
+                    # verify if the record's bookmark value is between start date and attribution window
+                    if self.parse_date(start_date_with_attribution_window) <= self.parse_date(replication_key_value) <= self.parse_date(start_date):
+                        is_between = True
 
-#                     self.assertTrue(is_between)
+                    self.assertTrue(is_between)

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -2,7 +2,7 @@ import base
 import os
 
 from tap_tester import runner, connections
-
+from tap_tester.base_case import BaseCase as base_case
 from base import FacebookBaseTest, LOGGER
 
 
@@ -44,7 +44,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return return_value
 
     # TODO: https://jira.talendforge.org/browse/TDL-26640
-    @base.skipUnless(base.JIRA_CLIENT.get_status_category("TDL-26640") == "done", "TDL-26640")
+    @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("TDL-26640") == "done", "TDL-26640")
     def test_run(self):
         """
         For the test ad set up in facebook ads manager we see data

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -9,6 +9,17 @@ from base import FacebookBaseTest
 class FacebookAttributionWindow(FacebookBaseTest):
 
     is_done = None
+    
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    EXCLUDE_STREAMS = {
+        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+        'ads_insights_platform_and_device', # TDL-26640
+        'ads_insights',                     # TDL-26640
+        'ads_insights_age_and_gender',      # TDL-26640
+        'ads_insights_country',             # TDL-26640
+        'ads_insights_dma',                 # TDL-26640
+        'ads_insights_region'               # TDL-26640
+    }
 
     @staticmethod
     def name():
@@ -21,7 +32,10 @@ class FacebookAttributionWindow(FacebookBaseTest):
         if self.is_done is None:
             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
             self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "ads_insights_hourly_advertiser stream to the test.")
+                                   "applicable EXCLUDE_STREAMS to the test.")
+            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+            # if either card is done, fail & update the test to include more streams
+            self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
         # return [stream for stream in self.expected_streams() if self.is_insight(stream)]

--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -29,20 +29,20 @@ class FacebookAutomaticFields(FacebookBaseTest):
         return "tap_tester_facebook_automatic_fields"
 
     def streams_to_test(self):
-        exprected_streams = self.expected_metadata().keys()
+        expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
         assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
-        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
         assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
             self.assert_message.format(self.EXCLUDE_STREAMS)
-        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 
-        return exprected_streams
+        return expected_streams
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""

--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -3,7 +3,7 @@ Test that with no fields selected for a stream automatic fields are still replic
 """
 import os
 
-from tap_tester import runner, connections
+from tap_tester import runner, connections, LOGGER
 import base
 from base import FacebookBaseTest
 
@@ -29,18 +29,20 @@ class FacebookAutomaticFields(FacebookBaseTest):
         return "tap_tester_facebook_automatic_fields"
 
     def streams_to_test(self):
-        # return set(self.expected_metadata().keys())
-        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-        if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-            self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "applicable EXCLUDE_STREAMS to the test.")
-            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-            # if either card is done, fail & update the test to include more streams
-            self.is_done = self.is_done or self.is_done_2
-        assert self.is_done != True, self.assert_message
+        exprected_streams = self.expected_metadata().keys()
+        self.assert_message = f"JIRA ticket has moved to done, \
+                                re-add the applicable stream to the test: {0}"
+        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+            self.assert_message.format('ads_insights_hourly_advertiser')
+        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
-        return self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
+            self.assert_message.format(self.EXCLUDE_STREAMS)
+        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
+
+        return exprected_streams
 
     def get_properties(self, original: bool = True):
         """Configuration properties required for the tap."""

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -117,7 +117,8 @@ class FacebookBookmarks(FacebookBaseTest):
         # Testing against ads insights objects
         self.start_date = self.get_properties()['start_date']
         self.end_date = self.get_properties()['end_date']
-        self.bookmarks_test(insight_streams)
+        # TODO: https://jira.talendforge.org/browse/TDL-26640
+        # self.bookmarks_test(insight_streams)
 
         # Testing against core objects
         self.end_date = '2021-02-09T00:00:00Z'

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -12,7 +12,7 @@ from base import FacebookBaseTest
 class FacebookBookmarks(FacebookBaseTest):
 
     is_done = None
-    
+
     # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
         'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
@@ -39,7 +39,7 @@ class FacebookBookmarks(FacebookBaseTest):
             self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
-        return self.expected_streams() - {'ads_insights_hourly_advertiser'}
+        return self.expected_streams() - self.EXCLUDE_STREAMS
 
     @staticmethod
     def convert_state_to_utc(date_str):

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -12,6 +12,17 @@ from base import FacebookBaseTest
 class FacebookBookmarks(FacebookBaseTest):
 
     is_done = None
+    
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    EXCLUDE_STREAMS = {
+        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+        'ads_insights_platform_and_device', # TDL-26640
+        'ads_insights',                     # TDL-26640
+        'ads_insights_age_and_gender',      # TDL-26640
+        'ads_insights_country',             # TDL-26640
+        'ads_insights_dma',                 # TDL-26640
+        'ads_insights_region'               # TDL-26640
+    }
 
     @staticmethod
     def name():
@@ -22,7 +33,10 @@ class FacebookBookmarks(FacebookBaseTest):
         if self.is_done is None:
             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
             self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "ads_insights_hourly_advertiser stream to the test.")
+                                   "applicable EXCLUDE_STREAMS to the test.")
+            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+            # if either card is done, fail & update the test to include more streams
+            self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
         return self.expected_streams() - {'ads_insights_hourly_advertiser'}

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -29,20 +29,20 @@ class FacebookBookmarks(FacebookBaseTest):
         return "tap_tester_facebook_bookmarks"
 
     def streams_to_test(self):
-        exprected_streams = self.expected_metadata().keys()
+        expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
         assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
-        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
         assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
             self.assert_message.format(self.EXCLUDE_STREAMS)
-        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 
-        return exprected_streams
+        return expected_streams
 
     @staticmethod
     def convert_state_to_utc(date_str):
@@ -120,7 +120,12 @@ class FacebookBookmarks(FacebookBaseTest):
         # Testing against ads insights objects
         self.start_date = self.get_properties()['start_date']
         self.end_date = self.get_properties()['end_date']
+
         # TODO: https://jira.talendforge.org/browse/TDL-26640
+        status_category = base.JIRA_CLIENT.get_status_category("TDL-26640")
+        assert status_category != 'done',\
+            "TDL-26640 is fixed, re-enable the test for insights streams"
+        # Uncomment the following line when ready to run the test for insights streams
         # self.bookmarks_test(insight_streams)
 
         # Testing against core objects

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -12,6 +12,17 @@ class FacebookStartDateTest(FacebookBaseTest):
     start_date_1 = ""
     start_date_2 = ""
 
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    EXCLUDE_STREAMS = {
+        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+        'ads_insights_platform_and_device', # TDL-26640
+        'ads_insights',                     # TDL-26640
+        'ads_insights_age_and_gender',      # TDL-26640
+        'ads_insights_country',             # TDL-26640
+        'ads_insights_dma',                 # TDL-26640
+        'ads_insights_region'               # TDL-26640
+    }
+
     @staticmethod
     def name():
         return "tap_tester_facebook_start_date_test"
@@ -21,7 +32,10 @@ class FacebookStartDateTest(FacebookBaseTest):
         if self.is_done is None:
             self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
             self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "ads_insights_hourly_advertiser stream to the test.")
+                                   "applicable EXCLUDE_STREAMS to the test.")
+            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+            # if either card is done, fail & update the test to include more streams
+            self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
         return self.expected_streams() - {'ads_insights_hourly_advertiser'}

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -28,20 +28,20 @@ class FacebookStartDateTest(FacebookBaseTest):
         return "tap_tester_facebook_start_date_test"
 
     def streams_to_test(self):
-        exprected_streams = self.expected_metadata().keys()
+        expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
         assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
-        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
         assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
             self.assert_message.format(self.EXCLUDE_STREAMS)
-        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 
-        return exprected_streams
+        return expected_streams
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -28,17 +28,20 @@ class FacebookStartDateTest(FacebookBaseTest):
         return "tap_tester_facebook_start_date_test"
 
     def streams_to_test(self):
-        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-        if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-            self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "applicable EXCLUDE_STREAMS to the test.")
-            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-            # if either card is done, fail & update the test to include more streams
-            self.is_done = self.is_done or self.is_done_2
-        assert self.is_done != True, self.assert_message
+        exprected_streams = self.expected_metadata().keys()
+        self.assert_message = f"JIRA ticket has moved to done, \
+                                re-add the applicable stream to the test: {0}"
+        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+            self.assert_message.format('ads_insights_hourly_advertiser')
+        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
-        return self.expected_streams() - self.EXCLUDE_STREAMS
+        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
+            self.assert_message.format(self.EXCLUDE_STREAMS)
+        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
+
+        return exprected_streams
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -38,7 +38,7 @@ class FacebookStartDateTest(FacebookBaseTest):
             self.is_done = self.is_done or self.is_done_2
         assert self.is_done != True, self.assert_message
 
-        return self.expected_streams() - {'ads_insights_hourly_advertiser'}
+        return self.expected_streams() - self.EXCLUDE_STREAMS
 
     def test_run(self):
         """Instantiate start date according to the desired data set and run the test"""

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -4,6 +4,7 @@ import datetime
 import base
 from base_new_frmwrk import FacebookBaseTest
 from tap_tester.base_suite_tests.table_reset_test import TableResetTest
+from tap_tester import LOGGER
 
 
 class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
@@ -28,18 +29,20 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
     }
 
     def streams_to_test(self):
-        # return set(self.expected_metadata().keys())
-        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
-        if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
-            self.assert_message = ("JIRA ticket has moved to done, re-add the "
-                                   "applicable EXCLUDE_STREAMS to the test.")
-            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
-            # if either card is done, fail & update the test to include more streams
-            self.is_done = self.is_done or self.is_done_2
-        assert self.is_done != True, self.assert_message
+        exprected_streams = self.expected_metadata().keys()
+        self.assert_message = f"JIRA ticket has moved to done, \
+                                re-add the applicable stream to the test: {0}"
+        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+            self.assert_message.format('ads_insights_hourly_advertiser')
+        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
-        return self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
+            self.assert_message.format(self.EXCLUDE_STREAMS)
+        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
+
+        return exprected_streams
 
     @property
     def reset_stream(self):

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -1,6 +1,7 @@
 import os
 import dateutil.parser
 import datetime
+import base
 from base_new_frmwrk import FacebookBaseTest
 from tap_tester.base_suite_tests.table_reset_test import TableResetTest
 
@@ -9,12 +10,36 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
     """tap-salesforce Table reset test implementation
     Currently tests only the stream with Incremental replication method"""
 
+    is_done = None
+    
     @staticmethod
     def name():
         return "tt_facebook_table_reset"
 
+    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    EXCLUDE_STREAMS = {
+        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
+        'ads_insights_platform_and_device', # TDL-26640
+        'ads_insights',                     # TDL-26640
+        'ads_insights_age_and_gender',      # TDL-26640
+        'ads_insights_country',             # TDL-26640
+        'ads_insights_dma',                 # TDL-26640
+        'ads_insights_region'               # TDL-26640
+    }
+
     def streams_to_test(self):
-        return self.expected_stream_names()
+        # return set(self.expected_metadata().keys())
+        # Fail the test when the JIRA card is done to allow stream to be re-added and tested
+        if self.is_done is None:
+            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
+            self.assert_message = ("JIRA ticket has moved to done, re-add the "
+                                   "applicable EXCLUDE_STREAMS to the test.")
+            self.is_done_2 = base.JIRA_CLIENT.get_status_category("TDL-26640") == 'done'
+            # if either card is done, fail & update the test to include more streams
+            self.is_done = self.is_done or self.is_done_2
+        assert self.is_done != True, self.assert_message
+
+        return self.expected_metadata().keys() - self.EXCLUDE_STREAMS
 
     @property
     def reset_stream(self):

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -12,7 +12,7 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
     Currently tests only the stream with Incremental replication method"""
 
     is_done = None
-    
+
     @staticmethod
     def name():
         return "tt_facebook_table_reset"
@@ -29,20 +29,20 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
     }
 
     def streams_to_test(self):
-        exprected_streams = self.expected_metadata().keys()
+        expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
         assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
-        exprected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
+        expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
 
         assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
             self.assert_message.format(self.EXCLUDE_STREAMS)
-        exprected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
+        expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 
-        return exprected_streams
+        return expected_streams
 
     @property
     def reset_stream(self):

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -18,9 +18,9 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
 
     @property
     def reset_stream(self):
-        return ('ads_insights_dma')
+        return ('ads')
 
-    
+
     def calculated_states_by_stream(self, current_state):
 
         """        The following streams barely make the cut:


### PR DESCRIPTION
# Description of change
## API Version Update

- Upgrading Facebook Marketing API SDK from v19 to v21.0.5
- Reason: Facebook Marketing API v19 will reach end-of-life on February 4, 2025
- This is a proactive upgrade to ensure continued API compatibility

# Testing Changes 

1. Current Situation
- All campaigns in the Facebook test account are currently paused
- Due to paused campaigns, no insight data is being generated
- Impact: Unable to test insight-related data streams

# Test Modifications

1. Integration Tests:

- Temporarily excluded all insights stream testing
- This includes metrics like impressions, clicks, and conversion data

2. Attribution Window Testing:

- Attribution window tests have been commented out
- These tests were specifically designed for insights streams
- Will need to be re-enabled once test data is available

# Manuak QA Steps:

1. Check API version compatibility:
- Confirm all existing endpoints work with v21.0.5
- Verify response formats haven't changed

# Risks

## API Version Related:

- Potential breaking changes in v21.0.5
- New endpoint formats or deprecated features
- Response schema modifications


## Testing Coverage:

- Reduced test coverage due to disabled insight tests
- Potential issues might go undetected in insights-related functionality

# Mitigation Steps

## Plan to re-enable insight tests:

- Create new active test campaigns
- Update test data sets
- Re-implement attribution window tests

# Rollback Steps

- Revert this branch to previous version
- This will restore v19 API implementation