### PR TITLE
Add default value of missing pk for ads_insights_hourly_advertiser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.23.0
+  * Add default value of missing pk for ads_insights_hourly_advertiser [#250](https://github.com/singer-io/tap-facebook/pull/250)
+
 ## 1.22.1
   * Bump dependency versions for twistlock compliance [#247](https://github.com/singer-io/tap-facebook/pull/247)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.22.1',
+      version='1.23.0',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -51,6 +51,7 @@ INSIGHTS_MAX_ASYNC_SLEEP_SECONDS = 5 * 60
 RESULT_RETURN_LIMIT = 100
 
 REQUEST_TIMEOUT = 300
+DEFAULT_PK_VALUE = "00:00:00 - 00:59:59"
 
 STREAMS = [
     'adcreative',
@@ -779,7 +780,7 @@ class AdsInsights(Stream):
                 # the API does not return hourly_stats_aggregated_by_advertiser_time_zone in the response.
                 # As it is one of the primary keys, we need to ensure it is present.
                 if self.name == "ads_insights_hourly_advertiser" and "hourly_stats_aggregated_by_advertiser_time_zone" not in rec:
-                    rec["hourly_stats_aggregated_by_advertiser_time_zone"] = None
+                    rec["hourly_stats_aggregated_by_advertiser_time_zone"] = DEFAULT_PK_VALUE
 
                 yield {'record': rec}
             LOGGER.info('Got %d results for insights job', count)

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -774,6 +774,13 @@ class AdsInsights(Stream):
                 rec = obj.export_all_data()
                 if not min_date_start_for_job or rec['date_stop'] < min_date_start_for_job:
                     min_date_start_for_job = rec['date_stop']
+
+                # When the impressions count remains 0 for the specific campaign throughout the day, 
+                # the API does not return hourly_stats_aggregated_by_advertiser_time_zone in the response.
+                # As it is one of the primary keys, we need to ensure it is present.
+                if self.name == "ads_insights_hourly_advertiser" and "hourly_stats_aggregated_by_advertiser_time_zone" not in rec:
+                    rec["hourly_stats_aggregated_by_advertiser_time_zone"] = None
+
                 yield {'record': rec}
             LOGGER.info('Got %d results for insights job', count)
 


### PR DESCRIPTION
# Description of change
- API occasionally does not return the `hourly_stats_aggregated_by_advertiser_time_zone` fields in the response, which serve as the primary key.  I’ve observed that when the `impressions count remains 0` for the specific campaign throughout the day, the API does not return `hourly_stats_aggregated_by_advertiser_time_zone` in the response. 
- That's why considering to explicitly add this key with a default value `00:00:00 - 00:59:59`.

# Manual QA steps
 - Run the tap for `hourly_stats_aggregated_by_advertiser_time_zone` stream and verified that it add default explicit value only if it is missing.
 - Run the tap for other streams and verified that it does add default pk value in any case.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
