### PR TITLE
Bump fb api version 23 0 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,4 +95,5 @@ ENV/
 # Custom stuff
 env.sh
 config.json
+properties.json
 .autoenv.zsh

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-facebook',
       install_requires=[
           'attrs==17.3.0',
           'backoff==2.2.1',
-          'facebook_business==21.0.5',
+          'facebook_business==23.0.1',
           'pendulum==1.2.0',
           'requests==2.32.4',
           'singer-python==6.0.1',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.23.0',
+      version='1.24.0',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,7 +9,7 @@ from tap_tester.logger import LOGGER
 class TestClient():
     def __init__(self):
         self.base_url  = 'https://graph.facebook.com'
-        self.api_version = 'v21.0'
+        self.api_version = 'v23.0'
         self.account_id = os.getenv('TAP_FACEBOOK_ACCOUNT_ID')
         self.access_token  = os.getenv('TAP_FACEBOOK_ACCESS_TOKEN')
         self.account_url = f"{self.base_url}/{self.api_version}/act_{self.account_id}"


### PR DESCRIPTION
# Description of change
The current tap relies on v21.0.5 of the facebook business API SDK. Facebook Marketing API version v21.0 is going to be [deprecated on Sep 9, 2025](https://developers.facebook.com/docs/marketing-api/marketing-api-changelog/versions). This change upgrades the API version to v23.0

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
