### PR TITLE
Update facebook_business dependency version to 25.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='tap-facebook',
       install_requires=[
           'attrs==17.3.0',
           'backoff==2.2.1',
-          'facebook_business==23.0.1',
+          'facebook_business==25.0.1',
           'pendulum==1.2.0',
           'requests==2.32.4',
           'singer-python==6.0.1',


### PR DESCRIPTION
# Description of change
Facebook Marketing API version v23.0 is going to be [deprecated on June 9, 2026](https://developers.facebook.com/docs/marketing-api/marketing-api-changelog/versions). This change upgrades the API client version to v25.0

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
