### PR TITLE
Skip tests for streams with no ads data.

### DIFF
--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -13,7 +13,7 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
 
     is_done = None
 
-    # https://jira.talendforge.org/browse/TDL-24424
+    # https://qlik-dev.atlassian.net/browse/SAC-24424
     MISSING_FIELDS = {
         "ads_insights" : {
             'outbound_clicks',

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -210,7 +210,7 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
     }
 
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_hourly_advertiser',    # SAC-24312
         'ads_insights_platform_and_device',  # SAC-30725
         'ads_insights',                      # SAC-30725
         'ads_insights_age_and_gender',       # SAC-30725
@@ -233,7 +233,7 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
-        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+        assert base.JIRA_CLIENT.get_status_category("SAC-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")

--- a/tests/test_facebook_all_fields.py
+++ b/tests/test_facebook_all_fields.py
@@ -209,15 +209,14 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
         }
     }
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
+        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_platform_and_device',  # SAC-30725
+        'ads_insights',                      # SAC-30725
+        'ads_insights_age_and_gender',       # SAC-30725
+        'ads_insights_country',              # SAC-30725
+        'ads_insights_dma',                  # SAC-30725
+        'ads_insights_region'                # SAC-30725
     }
 
     FICKLE_FIELDS = {
@@ -238,9 +237,6 @@ class FacebookAllFieldsTest(AllFieldsTest, FacebookBaseTest):
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
-
-        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
-            self.assert_message.format(self.EXCLUDE_STREAMS)
         expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -44,7 +44,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return return_value
 
     # TODO: https://jira.talendforge.org/browse/TDL-26640
-    @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("SAC-30725") == "done", "AC-30725")
+    @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("SAC-30725") == "done", "SAC-30725")
     def test_run(self):
         """
         For the test ad set up in facebook ads manager we see data

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -44,7 +44,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return return_value
 
     # TODO: https://jira.talendforge.org/browse/TDL-26640
-    @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("TDL-26640") == "done", "TDL-26640")
+    @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("SAC-30725") == "done", "AC-30725")
     def test_run(self):
         """
         For the test ad set up in facebook ads manager we see data

--- a/tests/test_facebook_attribution_window.py
+++ b/tests/test_facebook_attribution_window.py
@@ -19,7 +19,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
 
         # Fail the test when the JIRA card is done to allow stream to be re-added and tested
         if self.is_done is None:
-            self.is_done = base.JIRA_CLIENT.get_status_category("TDL-24312") == 'done'
+            self.is_done = base.JIRA_CLIENT.get_status_category("SAC-24312") == 'done'
             self.assert_message = ("JIRA ticket has moved to done, re-add the "
                                    "ads_insights_hourly_advertiser stream to the test.")
         assert self.is_done != True, self.assert_message
@@ -43,7 +43,7 @@ class FacebookAttributionWindow(FacebookBaseTest):
         return_value["start_date"] = self.start_date
         return return_value
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    # TODO: https://qlik-dev.atlassian.net/browse/SAC-30725
     @base_case.skipUnless(base.JIRA_CLIENT.get_status_category("SAC-30725") == "done", "SAC-30725")
     def test_run(self):
         """

--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -13,15 +13,14 @@ class FacebookAutomaticFields(FacebookBaseTest):
 
     is_done = None
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
+        'ads_insights_hourly_advertiser',   # TDL-24312
+        'ads_insights_platform_and_device',
+        'ads_insights',
+        'ads_insights_age_and_gender',
+        'ads_insights_country',
+        'ads_insights_dma',
+        'ads_insights_region'
     }
 
     @staticmethod
@@ -36,9 +35,6 @@ class FacebookAutomaticFields(FacebookBaseTest):
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
-
-        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
-            self.assert_message.format(self.EXCLUDE_STREAMS)
         expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 

--- a/tests/test_facebook_automatic_fields.py
+++ b/tests/test_facebook_automatic_fields.py
@@ -14,13 +14,13 @@ class FacebookAutomaticFields(FacebookBaseTest):
     is_done = None
 
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312
-        'ads_insights_platform_and_device',
-        'ads_insights',
-        'ads_insights_age_and_gender',
-        'ads_insights_country',
-        'ads_insights_dma',
-        'ads_insights_region'
+        'ads_insights_hourly_advertiser',    # SAC-24312
+        'ads_insights_platform_and_device',  # SAC-30725
+        'ads_insights',                      # SAC-30725
+        'ads_insights_age_and_gender',       # SAC-30725
+        'ads_insights_country',              # SAC-30725
+        'ads_insights_dma',                  # SAC-30725
+        'ads_insights_region'                # SAC-30725
     }
 
     @staticmethod
@@ -31,7 +31,7 @@ class FacebookAutomaticFields(FacebookBaseTest):
         expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
-        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+        assert base.JIRA_CLIENT.get_status_category("SAC-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -117,10 +117,10 @@ class FacebookBookmarks(FacebookBaseTest):
         self.start_date = self.get_properties()['start_date']
         self.end_date = self.get_properties()['end_date']
 
-        # TODO: https://jira.talendforge.org/browse/TDL-26640
-        status_category = base.JIRA_CLIENT.get_status_category("TDL-26640")
+        # TODO: https://qlik-dev.atlassian.net/browse/SAC-30725
+        status_category = base.JIRA_CLIENT.get_status_category("SAC-30725")
         assert status_category != 'done',\
-            "TDL-26640 is fixed, re-enable the test for insights streams"
+            "SAC-30725 is fixed, re-enable the test for insights streams"
         # Uncomment the following line when ready to run the test for insights streams
         # self.bookmarks_test(insight_streams)
 

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -14,7 +14,7 @@ class FacebookBookmarks(FacebookBaseTest):
     is_done = None
 
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_hourly_advertiser',    # SAC-24312
         'ads_insights_platform_and_device',  # SAC-30725
         'ads_insights',                      # SAC-30725
         'ads_insights_age_and_gender',       # SAC-30725
@@ -31,7 +31,7 @@ class FacebookBookmarks(FacebookBaseTest):
         expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
-        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+        assert base.JIRA_CLIENT.get_status_category("SAC-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")

--- a/tests/test_facebook_bookmarks.py
+++ b/tests/test_facebook_bookmarks.py
@@ -13,15 +13,14 @@ class FacebookBookmarks(FacebookBaseTest):
 
     is_done = None
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
+        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_platform_and_device',  # SAC-30725
+        'ads_insights',                      # SAC-30725
+        'ads_insights_age_and_gender',       # SAC-30725
+        'ads_insights_country',              # SAC-30725
+        'ads_insights_dma',                  # SAC-30725
+        'ads_insights_region'                # SAC-30725
     }
 
     @staticmethod
@@ -36,9 +35,6 @@ class FacebookBookmarks(FacebookBaseTest):
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
-
-        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
-            self.assert_message.format(self.EXCLUDE_STREAMS)
         expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 

--- a/tests/test_facebook_invalid_attribution_window.py
+++ b/tests/test_facebook_invalid_attribution_window.py
@@ -57,9 +57,9 @@ class FacebookInvalidAttributionWindowStr(FacebookInvalidAttributionWindowInt):
     def name():
         return "tt_facebook_invalid_window_str"
     
-    @unittest.skip("BUG: TDL-18569")
+    @unittest.skip("BUG: SAC-18569")
     def test_run(self):
         self.ATTRIBUTION_WINDOW = 'something'
         self.run_test()
 
-    # BUG : TDL-18569 created to standarize the error message for sting values for attribution window
+    # BUG : SAC-18569 created to standarize the error message for sting values for attribution window

--- a/tests/test_facebook_start_date.py
+++ b/tests/test_facebook_start_date.py
@@ -12,15 +12,15 @@ class FacebookStartDateTest(FacebookBaseTest):
     start_date_1 = ""
     start_date_2 = ""
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
+    # TODO: https://qlik-dev.atlassian.net/browse/SAC-30725
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
+        'ads_insights_hourly_advertiser',    # SAC-24312
+        'ads_insights_platform_and_device',  # SAC-30725
+        'ads_insights',                      # SAC-30725
+        'ads_insights_age_and_gender',       # SAC-30725
+        'ads_insights_country',              # SAC-30725
+        'ads_insights_dma',                  # SAC-30725
+        'ads_insights_region'                # SAC-30725
     }
 
     @staticmethod
@@ -31,13 +31,10 @@ class FacebookStartDateTest(FacebookBaseTest):
         expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
-        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+        assert base.JIRA_CLIENT.get_status_category("SAC-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
-
-        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
-            self.assert_message.format(self.EXCLUDE_STREAMS)
         expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -17,15 +17,14 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
     def name():
         return "tt_facebook_table_reset"
 
-    # TODO: https://jira.talendforge.org/browse/TDL-26640
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',   # TDL-24312, TDL-26640
-        'ads_insights_platform_and_device', # TDL-26640
-        'ads_insights',                     # TDL-26640
-        'ads_insights_age_and_gender',      # TDL-26640
-        'ads_insights_country',             # TDL-26640
-        'ads_insights_dma',                 # TDL-26640
-        'ads_insights_region'               # TDL-26640
+        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_platform_and_device',  # SAC-30725
+        'ads_insights',                      # SAC-30725
+        'ads_insights_age_and_gender',       # SAC-30725
+        'ads_insights_country',              # SAC-30725
+        'ads_insights_dma',                  # SAC-30725
+        'ads_insights_region'                # SAC-30725
     }
 
     def streams_to_test(self):
@@ -36,9 +35,6 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")
-
-        assert base.JIRA_CLIENT.get_status_category("TDL-26640") != 'done',\
-            self.assert_message.format(self.EXCLUDE_STREAMS)
         expected_streams = self.expected_metadata().keys() - self.EXCLUDE_STREAMS
         LOGGER.warn(f"Skipped streams: {self.EXCLUDE_STREAMS}")
 

--- a/tests/test_facebook_table_reset.py
+++ b/tests/test_facebook_table_reset.py
@@ -18,7 +18,7 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
         return "tt_facebook_table_reset"
 
     EXCLUDE_STREAMS = {
-        'ads_insights_hourly_advertiser',    # TDL-24312
+        'ads_insights_hourly_advertiser',    # SAC-24312
         'ads_insights_platform_and_device',  # SAC-30725
         'ads_insights',                      # SAC-30725
         'ads_insights_age_and_gender',       # SAC-30725
@@ -31,7 +31,7 @@ class FacebookTableResetTest(TableResetTest, FacebookBaseTest):
         expected_streams = self.expected_metadata().keys()
         self.assert_message = f"JIRA ticket has moved to done, \
                                 re-add the applicable stream to the test: {0}"
-        assert base.JIRA_CLIENT.get_status_category("TDL-24312") != 'done',\
+        assert base.JIRA_CLIENT.get_status_category("SAC-24312") != 'done',\
             self.assert_message.format('ads_insights_hourly_advertiser')
         expected_streams = self.expected_metadata().keys() - {'ads_insights_hourly_advertiser'}
         LOGGER.warn(f"Skipped streams: {'ads_insights_hourly_advertiser'}")


### PR DESCRIPTION
# Description of change

- The JIRA SAC-26640 was moved to Done which caused assertion issues on all the tests as the test check for the status of the JIRA to proceed further. Since the streams for the test_facebook_attribution_window have no ads data it is important to skip these tests until we can run fresh ads to generate new data.
- Removed all references to old jira card, replaced with new one. Also renamed all references to TDL to SAC key for jira.

New Reference Card: https://qlik-dev.atlassian.net/browse/SAC-30725

