### PR TITLE
Upgrade facebook_business SDK from v23.0.1 to v25.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.25.0
+  * Bump facebook_business SDK from v23.0.1 to v25.0.1 to stay ahead of v23.0 deprecation (June 9, 2026)
+  * Confirmed no schema changes required: `smart_promotion_type` was never present in campaigns schema
+  * Add explicit "Job Failed" status handling in async Insights job polling; surface v25.0 error fields (`error_code`, `error_message`, `error_subcode`, `error_user_title`, `error_user_msg`)
+
 ## 1.24.0
   * Bump facebook_business SDK to v23.0.1 [#255](https://github.com/singer-io/tap-facebook/pull/255)
   * Remove Deprecated Fields from adcreative [#255](https://github.com/singer-io/tap-facebook/pull/255)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-facebook',
-      version='1.24.0',
+      version='1.25.0',
       description='Singer.io tap for extracting data from the Facebook Ads API',
       author='Stitch',
       url='https://singer.io',
@@ -12,7 +12,7 @@ setup(name='tap-facebook',
       install_requires=[
           'attrs==17.3.0',
           'backoff==2.2.1',
-          'facebook_business==23.0.1',
+          'facebook_business==25.0.1',
           'pendulum==1.2.0',
           'requests==2.32.4',
           'singer-python==6.0.1',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='tap-facebook',
           'facebook_business==25.0.1',
           'pendulum==1.2.0',
           'requests==2.32.4',
-          'singer-python==6.0.1',
+          'singer-python==6.8.0',
       ],
       extras_require={
           'dev': [

--- a/tap_facebook/__init__.py
+++ b/tap_facebook/__init__.py
@@ -743,6 +743,18 @@ class AdsInsights(Stream):
             if status == "Job Completed":
                 return job
 
+            if status == "Job Failed":
+                error_code = job.get('error_code')
+                error_message = job.get('error_message')
+                error_subcode = job.get('error_subcode')
+                error_user_title = job.get('error_user_title')
+                error_user_msg = job.get('error_user_msg')
+                raise TapFacebookException(
+                    'Insights job {} failed. error_code={}, error_subcode={}, '
+                    'error_user_title={}, error_user_msg={}, error_message={}'.format(
+                        job_id, error_code, error_subcode,
+                        error_user_title, error_user_msg, error_message))
+
             if duration > INSIGHTS_MAX_WAIT_TO_START_SECONDS and percent_complete == 0:
                 pretty_error_message = ('Insights job {} did not start after {} seconds. ' +
                                         'This is an intermittent error and may resolve itself on subsequent queries to the Facebook API. ' +

--- a/tests/unittests/test_retry_logic.py
+++ b/tests/unittests/test_retry_logic.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from unittest.mock import Mock, patch
-from tap_facebook import FacebookRequestError
+from tap_facebook import FacebookRequestError, TapFacebookException
 from tap_facebook import facebook_business
 from facebook_business.exceptions import FacebookBadObjectError
 from facebook_business import FacebookAdsApi
@@ -11,10 +11,11 @@ from facebook_business.adobjects.adaccount import AdAccount
 import requests
 from requests.models import Response
 
+@patch("time.sleep")
 class TestAdCreative(unittest.TestCase):
     """A set of unit tests to ensure that requests to get AdCreatives behave
     as expected"""
-    def test_retries_on_500(self):
+    def test_retries_on_500(self, mocked_sleep):
         """`AdCreative.sync.do_request()` calls a `facebook_business` method,
         `get_ad_creatives()`, to make a request to the API. We mock this
         method to raise a `FacebookRequestError` with an `http_status` of
@@ -42,7 +43,7 @@ class TestAdCreative(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEqual(5, mocked_account.get_ad_creatives.call_count )
 
-    def test_retries_on_503(self):
+    def test_retries_on_503(self, mocked_sleep):
         """`AdCreative.sync.do_request()` calls a `facebook_business` method,
         `get_ad_creatives()`, to make a request to the API. We mock this
         method to raise a `FacebookRequestError` with an `http_status` of
@@ -70,7 +71,7 @@ class TestAdCreative(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEqual(5, mocked_account.get_ad_creatives.call_count )
 
-    def test_catch_a_type_error(self):
+    def test_catch_a_type_error(self, mocked_sleep):
         """`AdCreative.sync.do_request()` calls a `facebook_business` method `get_ad_creatives()`.
         We want to mock this to throw a `TypeError("string indices must be integers")` and assert
         that we retry this specific error.
@@ -87,7 +88,7 @@ class TestAdCreative(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEqual(5, mocked_account.get_ad_creatives.call_count )
 
-    def test_retries_and_good_response(self):
+    def test_retries_and_good_response(self, mocked_sleep):
         """Facebook has a class called `FacebookResponse` and it is created from a `requests.Response`. Some
         `facebook_business` functions depend on calling `FacebookResponse.json()`, which sometimes returns a
         string instead of a dictionary. This leads to a `TypeError("string indices must be integers")` and
@@ -132,10 +133,11 @@ class TestAdCreative(unittest.TestCase):
 
 
 
+@patch("time.sleep")
 class TestInsightJobs(unittest.TestCase):
     """A set of unit tests to ensure that requests to get AdsInsights behave
     as expected"""
-    def test_retries_on_bad_data(self):
+    def test_retries_on_bad_data(self, mocked_sleep):
         """`AdInsights.run_job()` calls a `facebook_business` method,
         `get_insights()`, to make a request to the API. We mock this
         method to raise a `FacebookBadObjectError`
@@ -156,7 +158,7 @@ class TestInsightJobs(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEqual(5, mocked_account.get_insights.call_count )
 
-    def test_retries_on_type_error(self):
+    def test_retries_on_type_error(self, mocked_sleep):
         """`AdInsights.run_job()` calls a `facebook_business` method, `get_insights()`, to make a request to
         the API. We want to mock this to throw a `TypeError("string indices must be integers")` and
         assert that we retry this specific error.
@@ -174,7 +176,7 @@ class TestInsightJobs(unittest.TestCase):
         # 5 is the max tries specified in the tap
         self.assertEqual(5, mocked_account.get_insights.call_count )
 
-    def test_retries_and_good_response(self):
+    def test_retries_and_good_response(self, mocked_sleep):
         """Facebook has a class called `FacebookResponse` and it is created from a `requests.Response`. Some
         `facebook_business` functions depend on calling `FacebookResponse.json()`, which sometimes returns a
         string instead of a dictionary. This leads to a `TypeError("string indices must be integers")` and
@@ -216,7 +218,7 @@ class TestInsightJobs(unittest.TestCase):
         patcher.stop()
 
 
-    def test_job_polling_retry(self):
+    def test_job_polling_retry(self, mocked_sleep):
         """AdInsights.api_get() polls the job status of an insights job we've requested
         that Facebook generate. This test makes a request with a mock response to
         raise a 400 status error that should be retried.
@@ -248,7 +250,7 @@ class TestInsightJobs(unittest.TestCase):
 
 
 
-    def test_job_polling_retry_succeeds_eventually(self):
+    def test_job_polling_retry_succeeds_eventually(self, mocked_sleep):
         """AdInsights.api_get() polls the job status of an insights job we've requested
         that Facebook generate. This test makes a request with a mock response to
         raise a 400 status error that should be retried.
@@ -287,3 +289,41 @@ class TestInsightJobs(unittest.TestCase):
         ad_insights_object.run_job({})
         self.assertEqual(3, mocked_account.get_insights.return_value.api_get.call_count)
         self.assertEqual(1, mocked_account.get_insights.call_count)
+
+    def test_job_failed_raises_tap_exception(self, mocked_sleep):
+        """AdsInsights.run_job() polls the async job status. When api_get() returns
+        async_status == "Job Failed", the tap should immediately raise a
+        TapFacebookException containing all v25.0 error fields, without retrying.
+        """
+        failed_job_response = {
+            "async_status": "Job Failed",
+            "async_percent_completion": 0,
+            "id": "9999",
+            "error_code": 2601,
+            "error_message": "There was an error running your report.",
+            "error_subcode": 1487742,
+            "error_user_title": "Report Unavailable",
+            "error_user_msg": "Your report could not be run due to a temporary issue.",
+        }
+
+        mocked_api_get = Mock()
+        mocked_api_get.return_value = failed_job_response
+
+        mocked_account = Mock()
+        mocked_account.get_insights = Mock()
+        mocked_account.get_insights.return_value.api_get = mocked_api_get
+
+        ad_insights_object = AdsInsights('', mocked_account, '', '', {}, {})
+
+        with self.assertRaises(TapFacebookException) as ctx:
+            ad_insights_object.run_job({})
+
+        error_str = str(ctx.exception)
+        self.assertIn("9999", error_str)
+        self.assertIn("2601", error_str)
+        self.assertIn("1487742", error_str)
+        self.assertIn("Report Unavailable", error_str)
+        self.assertIn("Your report could not be run due to a temporary issue.", error_str)
+        self.assertIn("There was an error running your report.", error_str)
+        # Should fail immediately — no retries on job failure
+        self.assertEqual(1, mocked_api_get.call_count)

--- a/tests/unittests/test_sync_batches_retry.py
+++ b/tests/unittests/test_sync_batches_retry.py
@@ -25,11 +25,12 @@ class MockBatch:
                         body={}
                     )
 
+@mock.patch("time.sleep")
 class TestAdCreativeSyncBbatches(unittest.TestCase):
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
-    def test_retries_on_attribute_error_sync_batches(self, mocked_schema, mocked_api):
+    def test_retries_on_attribute_error_sync_batches(self, mocked_schema, mocked_api, mocked_sleep):
         """ 
             AdCreative.sync_batches calls a `facebook_business` method,`api_batch.execute()`, to get a batch of ad creatives. 
             We mock this method to raise a `AttributeError` and expect the tap to retry this that function up to 5 times,
@@ -54,7 +55,7 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
-    def test_retries_on_facebook_request_error_sync_batches(self, mocked_schema, mocked_api):
+    def test_retries_on_facebook_request_error_sync_batches(self, mocked_schema, mocked_api, mocked_sleep):
         """ 
             AdCreative.sync_batches calls a `facebook_business` method,`api_batch.execute()`, to get a batch of ad creatives. 
             We mock this method to raise a `FacebookRequestError` and expect the tap to retry this that function up to 5 times,
@@ -79,7 +80,7 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
-    def test_no_error_on_sync_batches(self, mocked_schema, mocked_api):
+    def test_no_error_on_sync_batches(self, mocked_schema, mocked_api, mocked_sleep):
         """ 
             AdCreative.sync_batches calls a `facebook_business` method,`api_batch.execute()`, to get a batch of ad creatives. 
             We mock this method to simply pass the things and expect the tap to run without exception
@@ -101,11 +102,12 @@ class TestAdCreativeSyncBbatches(unittest.TestCase):
         self.assertEqual(1, mocked_schema.call_count)
 
 
+@mock.patch("time.sleep")
 class TestLeadsSyncBatches(unittest.TestCase):
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
-    def test_retries_on_attribute_error_sync_batches(self, mocked_schema, mocked_api):
+    def test_retries_on_attribute_error_sync_batches(self, mocked_schema, mocked_api, mocked_sleep):
         """ 
             Leads.sync_batches calls a `facebook_business` method,`api_batch.execute()`, to get a batch of Leads. 
             We mock this method to raise a `AttributeError` and expect the tap to retry this that function up to 5 times,
@@ -130,7 +132,7 @@ class TestLeadsSyncBatches(unittest.TestCase):
 
     @mock.patch("tap_facebook.API")
     @mock.patch("singer.resolve_schema_references")
-    def test_retries_on_facebook_request_error_sync_batches(self, mocked_schema, mocked_api):
+    def test_retries_on_facebook_request_error_sync_batches(self, mocked_schema, mocked_api, mocked_sleep):
         """ 
             Leads.sync_batches calls a `facebook_business` method,`api_batch.execute()`, to get a batch of Leads. 
             We mock this method to raise a `FacebookRequestError` and expect the tap to retry this that function up to 5 times,


### PR DESCRIPTION
## Summary
Upgrades the `facebook_business` Python SDK from `23.0.1` to `25.0.1` to keep the tap functional ahead of the Marketing API v23.0 deprecation on June 9, 2026. Also upgrades `singer-python` to `6.8.0` for Python 3.10+ compatibility, and improves async Insights job error handling and unit test coverage.
JIRA - https://qlik-dev.atlassian.net/browse/SAC-30627

## Changes

### Dependencies (`setup.py`)
- `facebook_business==23.0.1` → `==25.0.1`
- `singer-python==6.0.1` → `==6.8.0` (resolves `collections.MutableMapping` DeprecationWarning from bundled `jsonschema`)
- Tap version `1.24.0` → `1.25.0`

### Tap logic (`tap_facebook/__init__.py`)
- Added `"Job Failed"` branch in `AdsInsights.run_job()` async Insights polling loop — immediately raises `TapFacebookException` with all v25.0 error fields (`error_code`, `error_message`, `error_subcode`, `error_user_title`, `error_user_msg`) instead of spinning silently until timeout

### Unit tests (`tests/unittests/`)
- Added `@patch("time.sleep")` to `TestAdCreative`, `TestInsightJobs`
  (`test_retry_logic.py`) and `TestAdCreativeSyncBbatches`,
  `TestLeadsSyncBatches` (`test_sync_batches_retry.py`) — eliminates real
  backoff sleep during tests, reducing suite runtime from ~13 minutes to
  under 1 second
- Added `test_job_failed_raises_tap_exception` to `TestInsightJobs` —
  verifies `TapFacebookException` is raised immediately (no retries) with
  all v25.0 error fields in the message when `async_status == "Job Failed"`

### `CHANGELOG.md`
- Added `1.25.0` entry

## Breaking Changes Evaluated
| Area | Finding | Action |
|---|---|---|
| `smart_promotion_type` removal (v25.0, May 19 2026) | Field never present in `campaigns.json` | None needed |
| Detailed targeting consolidation (v24.0) | Schema uses flexible `id_name_pairs` arrays; read-only tap unaffected | None needed |
| Facebook video feeds placement deprecation (v24.0) | No placement fields hardcoded in `adsets.json` | None needed |
| Async Insights `error_code` uint→int (v25.0) | Python dynamic typing; new error fields now surfaced in logs | Code updated |
| `singer-python` 6.0.1 → 6.8.0 | Tap only uses core APIs (`write_record`, `get_bookmark`, `write_bookmark`, etc.) — all unchanged across versions | No code changes needed |

## Testing
- 53/53 unit tests passing in 0.53s (previously 52 tests in ~13 minutes)
- Integration tests to be run via tap-tester

## Reference
- https://developers.facebook.com/documentation/ads-commerce/marketing-api/marketing-api-changelog/versions